### PR TITLE
Add Vite React boilerplate with Tailwind, ESLint and Devcontainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# React-boilerplate-
+# React Vite Starter
+
+This project provides a boilerplate React application powered by Vite and TypeScript. It includes TailwindCSS v4, ESLint, Prettier, path aliases, Husky pre-commit hooks, and a VS Code DevContainer for a smooth development experience.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v18 or later
+- [npm](https://www.npmjs.com/)
+
+## Getting Started
+
+```bash
+npm install
+npm run dev       # start development server
+npm run build     # build for production
+npm run lint      # run ESLint and Prettier
+```
+
+## Environment Variables
+
+Create a `.env.local` file for local overrides. All client-exposed variables must begin with `VITE_APP_`.
+
+Example `.env`:
+
+```
+VITE_APP_API_URL=https://api.example.com
+```
+
+## VS Code DevContainer
+
+Open the project in VS Code and choose **Reopen in Container** if you have the Dev Containers extension installed. The container installs dependencies automatically and forwards port 3000 for the Vite server.

--- a/my-app/.devcontainer/Dockerfile
+++ b/my-app/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:18
+RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/my-app/.devcontainer/devcontainer.json
+++ b/my-app/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "React Vite Dev",
+  "build": { "dockerfile": "Dockerfile" },
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "forwardPorts": [3000],
+  "postCreateCommand": "npm install",
+  "remoteUser": "node"
+}

--- a/my-app/.env
+++ b/my-app/.env
@@ -1,0 +1,1 @@
+VITE_APP_API_URL=https://api.example.com

--- a/my-app/.eslintrc.cjs
+++ b/my-app/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  plugins: ['react', 'react-hooks', '@typescript-eslint'],
+  env: {
+    browser: true,
+    node: true,
+    es2021: true,
+  },
+  settings: {
+    react: { version: 'detect' },
+  },
+  rules: {
+    // Project-specific rule overrides
+  },
+};

--- a/my-app/.gitignore
+++ b/my-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env.local
+.DS_Store
+.vscode/

--- a/my-app/.husky/_/husky.sh
+++ b/my-app/.husky/_/husky.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) -" "$@"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook" && exit 0
+  fi
+  if [ -f ~/.huskyrc ]; then
+    debug "~/.huskyrc found, source..."
+    . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exit $?
+fi

--- a/my-app/.husky/pre-commit
+++ b/my-app/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/my-app/.prettierrc.cjs
+++ b/my-app/.prettierrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'es5',
+  printWidth: 100,
+  tabWidth: 2,
+};

--- a/my-app/index.html
+++ b/my-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "my-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext js,jsx,ts,tsx"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.24",
+    "@types/react-dom": "^18.0.8",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.2",
+    "vite": "^4.0.0",
+    "tailwindcss": "latest",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.47.0",
+    "prettier": "^2.8.8",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "@typescript-eslint/parser": "^5.59.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.0",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "husky": "^8.0.0",
+    "lint-staged": "^13.2.3"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  }
+}

--- a/my-app/postcss.config.cjs
+++ b/my-app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div className="p-6 text-center">
+      <h1 className="text-2xl font-bold">Hello Vite + React!</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/my-app/src/main.tsx
+++ b/my-app/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/my-app/src/styles/index.css
+++ b/my-app/src/styles/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/my-app/src/vite-env.d.ts
+++ b/my-app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/my-app/tailwind.config.js
+++ b/my-app/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx,html}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+  // Example safelist usage:
+  // safelist: ['bg-red-500', 'text-center'],
+};

--- a/my-app/tsconfig.json
+++ b/my-app/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/my-app/tsconfig.node.json
+++ b/my-app/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/my-app/vite.config.ts
+++ b/my-app/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold React + Vite + TypeScript project in `my-app`
- configure TailwindCSS v4 and PostCSS
- add ESLint/Prettier configuration and Husky pre‑commit hook
- enable TypeScript path aliases and Vite alias configuration
- provide devcontainer configuration for VS Code
- document setup and environment variables in README

## Testing
- `npm run lint` *(fails: ESLint not installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68691eec414883219c38f2827b62c71e