### PR TITLE
Implement core services and configuration

### DIFF
--- a/my-app/src/app/config/index.ts
+++ b/my-app/src/app/config/index.ts
@@ -1,2 +1,20 @@
-export const API_URL = import.meta.env.VITE_APP_API_URL;
-export { default as axios } from './axios';
+/**
+ * Read a required environment variable.
+ *
+ * @param key - Name of the environment variable
+ * @returns The value of the variable
+ * @throws Error if the variable is not set
+ */
+export function getEnv(key: string): string {
+  const value = import.meta.env[key];
+  if (!value) {
+    throw new Error('Missing env var: ' + key);
+  }
+  return value;
+}
+
+/** Base API URL configured via environment variables */
+export const API_URL = getEnv('VITE_APP_API_URL');
+
+/** URL used to refresh authentication tokens */
+export const REFRESH_URL = getEnv('VITE_APP_REFRESH_TOKEN_URL');

--- a/my-app/src/app/core/ApiError.ts
+++ b/my-app/src/app/core/ApiError.ts
@@ -1,0 +1,18 @@
+export interface ApiErrorProps {
+  status: number;
+  message: string;
+  details?: unknown;
+}
+
+/** Custom error object used by HttpClient */
+export class ApiError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor({ status, message, details }: ApiErrorProps) {
+    super(message);
+    this.status = status;
+    this.details = details;
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+}

--- a/my-app/src/app/core/AuthService.ts
+++ b/my-app/src/app/core/AuthService.ts
@@ -1,0 +1,90 @@
+import { REFRESH_URL } from '@app/config';
+
+export interface User {
+  id: string;
+  email: string;
+  roles: string[];
+}
+
+/**
+ * Authentication service handling tokens and role checks.
+ */
+export class AuthService {
+  private accessKey = 'app_access_token';
+  private refreshKey = 'app_refresh_token';
+  private roleKey = 'user_roles';
+
+  private constructor() {}
+  static instance = new AuthService();
+
+  /** Perform login and persist tokens */
+  async login(credentials: { email: string; password: string }): Promise<User> {
+    const res = await fetch(REFRESH_URL.replace('/refresh', '/login'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(credentials),
+    });
+    const data = await res.json();
+    this.storeTokens(data.accessToken, data.refreshToken);
+    if (data.user?.roles) {
+      localStorage.setItem(this.roleKey, JSON.stringify(data.user.roles));
+    }
+    return data.user as User;
+  }
+
+  /** Clear tokens from storage */
+  logout(): void {
+    localStorage.removeItem(this.accessKey);
+    localStorage.removeItem(this.refreshKey);
+    localStorage.removeItem(this.roleKey);
+  }
+
+  /** Get stored access token */
+  getAccessToken(): string | null {
+    return localStorage.getItem(this.accessKey);
+  }
+
+  /** Get stored refresh token */
+  getRefreshToken(): string | null {
+    return localStorage.getItem(this.refreshKey);
+  }
+
+  /** Refresh the access token */
+  async refreshToken(): Promise<string> {
+    const token = this.getRefreshToken();
+    if (!token) throw new Error('No refresh token');
+
+    const res = await fetch(REFRESH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken: token }),
+    });
+
+    if (!res.ok) {
+      throw new Error('Refresh failed');
+    }
+    const data = await res.json();
+    this.storeTokens(data.accessToken, data.refreshToken ?? token);
+    return data.accessToken as string;
+  }
+
+  /** Determine if user is authenticated */
+  isAuthenticated(): boolean {
+    return !!this.getAccessToken();
+  }
+
+  /** Check if user has the specified role */
+  hasRole(role: string): boolean {
+    const raw = localStorage.getItem(this.roleKey);
+    const roles: string[] = raw ? JSON.parse(raw) : [];
+    return roles.includes(role);
+  }
+
+  /** Persist tokens in local storage */
+  private storeTokens(access: string, refresh: string) {
+    localStorage.setItem(this.accessKey, access);
+    localStorage.setItem(this.refreshKey, refresh);
+  }
+}

--- a/my-app/src/app/core/ErrorBoundary.tsx
+++ b/my-app/src/app/core/ErrorBoundary.tsx
@@ -1,12 +1,25 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 
-interface Props { children: ReactNode }
-interface State { hasError: boolean }
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onReset?: () => void;
+}
 
-export class ErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false };
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
 
-  static getDerivedStateFromError(): State {
+/**
+ * Global React error boundary with reset capability.
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
     return { hasError: true };
   }
 
@@ -14,9 +27,20 @@ export class ErrorBoundary extends Component<Props, State> {
     console.error('Uncaught error:', error, info);
   }
 
+  private handleReset = () => {
+    this.setState({ hasError: false });
+    this.props.onReset?.();
+  };
+
   render() {
     if (this.state.hasError) {
-      return <h1>Something went wrong.</h1>;
+      if (this.props.fallback) return <>{this.props.fallback}</>;
+      return (
+        <div className="p-4 border rounded text-center">
+          <p>Something went wrong.</p>
+          <button onClick={this.handleReset}>Retry</button>
+        </div>
+      );
     }
 
     return this.props.children;

--- a/my-app/src/app/core/HttpClient.ts
+++ b/my-app/src/app/core/HttpClient.ts
@@ -1,5 +1,106 @@
-import axios from 'axios';
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+} from 'axios';
+import { API_URL } from '@app/config';
+import { AuthService } from './AuthService';
+import { ApiError } from './ApiError';
 
-export const HttpClient = axios.create({
-  baseURL: '/',
-});
+/**
+ * Typed HTTP client wrapper around Axios.
+ */
+export default class HttpClient {
+  private instance: AxiosInstance;
+
+  constructor(instance?: AxiosInstance) {
+    this.instance =
+      instance ??
+      axios.create({
+        baseURL: API_URL,
+        timeout: 30000,
+      });
+
+    this.instance.interceptors.request.use(this.onRequest.bind(this));
+    this.instance.interceptors.response.use(
+      this.onResponse.bind(this),
+      this.onError.bind(this),
+    );
+  }
+
+  /** Attach auth token to outgoing requests */
+  private onRequest(config: AxiosRequestConfig): AxiosRequestConfig {
+    const token = AuthService.instance.getAccessToken();
+    if (token) {
+      config.headers = config.headers ?? {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  }
+
+  private onResponse<T>(response: AxiosResponse<T>): T {
+    return response.data;
+  }
+
+  /**
+   * Handle errors and perform retries or token refresh when needed.
+   */
+  private async onError(error: AxiosError): Promise<never> {
+    const { config, response } = error;
+    const status = response?.status ?? 0;
+
+    // handle 401 by refreshing token once
+    if (status === 401 && config && !('retry' in config)) {
+      (config as any).retry = true;
+      await AuthService.instance.refreshToken();
+      const token = AuthService.instance.getAccessToken();
+      if (token && config.headers) {
+        (config.headers as any).Authorization = `Bearer ${token}`;
+      }
+      return this.instance(config);
+    }
+
+    // retry network/5xx errors up to two times
+    if (config) {
+      const retryCount = (config as any)._retryCount ?? 0;
+      if ((!response || status >= 500) && retryCount < 2) {
+        (config as any)._retryCount = retryCount + 1;
+        const delay = 300 * Math.pow(2, retryCount);
+        await new Promise(res => setTimeout(res, delay));
+        return this.instance(config);
+      }
+    }
+
+    // throw standardized ApiError
+    const message =
+      (response?.data as any)?.message || error.message || 'Request failed';
+    throw new ApiError({ status, message, details: response?.data });
+  }
+
+  // HTTP verb helpers
+  /** Perform HTTP GET */
+  get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.get<T, T>(url, config);
+  }
+
+  /** Perform HTTP POST */
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.post<T, T>(url, data, config);
+  }
+
+  /** Perform HTTP PUT */
+  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.put<T, T>(url, data, config);
+  }
+
+  /** Perform HTTP PATCH */
+  patch<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.patch<T, T>(url, data, config);
+  }
+
+  /** Perform HTTP DELETE */
+  delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
+    return this.instance.delete<T, T>(url, config);
+  }
+}

--- a/my-app/src/app/core/__tests__/AuthService.test.ts
+++ b/my-app/src/app/core/__tests__/AuthService.test.ts
@@ -1,0 +1,55 @@
+import { AuthService } from '../AuthService';
+
+const fetchMock = jest.fn();
+
+(global as any).fetch = fetchMock;
+
+describe('AuthService', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    localStorage.clear();
+  });
+
+  it('login stores tokens and returns user', async () => {
+    fetchMock.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          accessToken: 'a',
+          refreshToken: 'b',
+          user: { id: '1', email: 'e', roles: ['admin'] },
+        }),
+    });
+    const user = await AuthService.instance.login({ email: 'e', password: 'p' });
+    expect(user.email).toBe('e');
+    expect(localStorage.getItem('app_access_token')).toBe('a');
+  });
+
+  it('logout clears storage', () => {
+    localStorage.setItem('app_access_token', 'x');
+    AuthService.instance.logout();
+    expect(localStorage.getItem('app_access_token')).toBeNull();
+  });
+
+  it('refreshToken replaces token', async () => {
+    localStorage.setItem('app_refresh_token', 'old');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ accessToken: 'new', refreshToken: 'r' }),
+    });
+    const token = await AuthService.instance.refreshToken();
+    expect(token).toBe('new');
+    expect(localStorage.getItem('app_access_token')).toBe('new');
+  });
+
+  it('isAuthenticated works', () => {
+    expect(AuthService.instance.isAuthenticated()).toBe(false);
+    localStorage.setItem('app_access_token', 'x');
+    expect(AuthService.instance.isAuthenticated()).toBe(true);
+  });
+
+  it('hasRole checks roles', () => {
+    localStorage.setItem('user_roles', JSON.stringify(['admin']));
+    expect(AuthService.instance.hasRole('admin')).toBe(true);
+    expect(AuthService.instance.hasRole('user')).toBe(false);
+  });
+});

--- a/my-app/src/app/core/__tests__/HttpClient.test.ts
+++ b/my-app/src/app/core/__tests__/HttpClient.test.ts
@@ -1,0 +1,54 @@
+import HttpClient from '../HttpClient';
+import { AuthService } from '../AuthService';
+import { ApiError } from '../ApiError';
+
+jest.mock('../AuthService');
+
+function createMockInstance() {
+  const handlers: any = {};
+  const instance: any = {
+    interceptors: {
+      request: { use: jest.fn((fn: any) => (handlers.req = fn)) },
+      response: { use: jest.fn((res: any, err: any) => {
+        handlers.res = res;
+        handlers.err = err;
+      }) },
+    },
+    get: jest.fn(() => Promise.resolve({ data: 'ok' })),
+  };
+  return { instance, handlers };
+}
+
+describe('HttpClient', () => {
+  it('adds Authorization header', async () => {
+    (AuthService.instance.getAccessToken as jest.Mock).mockReturnValue('t');
+    const { instance, handlers } = createMockInstance();
+    const client = new HttpClient(instance);
+    const config = await handlers.req({ headers: {} });
+    expect(config.headers.Authorization).toBe('Bearer t');
+    expect(instance.interceptors.request.use).toHaveBeenCalled();
+    client; // satisfy unused variable
+  });
+
+  it('wraps errors as ApiError', async () => {
+    const { instance, handlers } = createMockInstance();
+    instance.get.mockRejectedValue({
+      config: {},
+      response: { status: 500, data: { message: 'fail' } },
+    });
+    const client = new HttpClient(instance);
+
+    try {
+      await handlers.err({
+        config: {},
+        response: { status: 500, data: { message: 'fail' } },
+        message: 'fail',
+      });
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(500);
+    }
+
+    client; // satisfy unused variable
+  });
+});

--- a/my-app/src/app/core/index.ts
+++ b/my-app/src/app/core/index.ts
@@ -1,2 +1,4 @@
-export * from './HttpClient';
-export * from './ErrorBoundary';
+export { ApiError } from './ApiError';
+export { default as HttpClient } from './HttpClient';
+export { AuthService } from './AuthService';
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## Summary
- add runtime env config helpers
- implement ApiError class
- create AuthService singleton
- implement typed HttpClient with interceptors
- enhance ErrorBoundary with fallback UI
- barrel export core services
- add unit test scaffolding for AuthService and HttpClient

## Testing
- `npm test` *(fails: Missing script and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686928c0252c8321a32d3b0bc4d2b9d9