### PR TITLE
Add central useAppStore slice

### DIFF
--- a/my-app/src/app/stores/index.ts
+++ b/my-app/src/app/stores/index.ts
@@ -17,3 +17,4 @@ export * from './useLoadingStore';
 export * from './useChatStore';
 export * from './hooks';
 export * from './testUtils';
+export { useAppStore } from './useAppStore';

--- a/my-app/src/app/stores/useAppStore.ts
+++ b/my-app/src/app/stores/useAppStore.ts
@@ -1,0 +1,43 @@
+/**
+ * Global application store for cross-cutting app state.
+ * Provides loading flags, error messages and mobile menu toggle.
+ * Use within React components via `useAppStore()`.
+ */
+import { create } from 'zustand';
+import { withDevtools, withPersist, withCombine } from './storeConfig';
+
+/**
+ * useAppStore – central app-level state:
+ * - isAppLoading: boolean
+ * - globalError: string | null
+ * - isMobileMenuOpen: boolean
+ */
+const initialAppState = {
+  isAppLoading: false,
+  globalError: null as string | null,
+  isMobileMenuOpen: false,
+};
+
+const appSlice = withCombine(
+  initialAppState,
+  (set) => ({
+    setAppLoading: (loading: boolean) => set({ isAppLoading: loading }),
+    setGlobalError: (message: string | null) => set({ globalError: message }),
+    toggleMobileMenu: () =>
+      set((state) => ({ isMobileMenuOpen: !state.isMobileMenuOpen })),
+  })
+);
+
+export const useAppStore = create<{
+  isAppLoading: boolean;
+  globalError: string | null;
+  isMobileMenuOpen: boolean;
+  setAppLoading: (loading: boolean) => void;
+  setGlobalError: (message: string | null) => void;
+  toggleMobileMenu: () => void;
+}>()(
+  withDevtools(
+    withPersist('app')(appSlice),
+    { name: 'app-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- add `useAppStore` Zustand slice for global app state
- export slice from store barrel file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686954c38784832189864254d6840b00