### PR TITLE
Add full typography library

### DIFF
--- a/my-app/src/library/components/typography/CodeBlock.tsx
+++ b/my-app/src/library/components/typography/CodeBlock.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface Props extends React.HTMLAttributes<HTMLPreElement> {
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
+  truncate?: boolean;
+  ellipsisLines?: number;
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+};
+
+const weightClasses: Record<NonNullable<Props['weight']>, string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const CodeBlock: React.FC<Props> = ({
+  size = 'md',
+  weight = 'normal',
+  truncate,
+  ellipsisLines,
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = [sizeClasses[size], weightClasses[weight]];
+  if (truncate) classes.push('truncate');
+  if (ellipsisLines) classes.push(`line-clamp-${ellipsisLines}`);
+  if (className) classes.push(className);
+  return (
+    <pre className={classes.join(' ')} {...rest}>
+      <code>{children}</code>
+    </pre>
+  );
+};
+
+export default CodeBlock;

--- a/my-app/src/library/components/typography/Heading.tsx
+++ b/my-app/src/library/components/typography/Heading.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+export interface Props extends React.HTMLAttributes<HTMLHeadingElement> {
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
+  truncate?: boolean;
+  ellipsisLines?: number;
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+};
+
+const weightClasses: Record<NonNullable<Props['weight']>, string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const Heading: React.FC<Props> = ({
+  level = 1,
+  size = 'md',
+  weight = 'normal',
+  truncate,
+  ellipsisLines,
+  className = '',
+  children,
+  ...rest
+}) => {
+  const Tag = `h${level}` as keyof JSX.IntrinsicElements;
+  const classes = [sizeClasses[size], weightClasses[weight]];
+  if (truncate) classes.push('truncate');
+  if (ellipsisLines) classes.push(`line-clamp-${ellipsisLines}`);
+  if (className) classes.push(className);
+  return (
+    <Tag className={classes.join(' ')} {...rest}>
+      {children}
+    </Tag>
+  );
+};
+
+export default Heading;

--- a/my-app/src/library/components/typography/InlineCode.tsx
+++ b/my-app/src/library/components/typography/InlineCode.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface Props extends React.HTMLAttributes<HTMLElement> {
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
+  truncate?: boolean;
+  ellipsisLines?: number;
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+};
+
+const weightClasses: Record<NonNullable<Props['weight']>, string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const InlineCode: React.FC<Props> = ({
+  size = 'md',
+  weight = 'normal',
+  truncate,
+  ellipsisLines,
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = [sizeClasses[size], weightClasses[weight]];
+  if (truncate) classes.push('truncate');
+  if (ellipsisLines) classes.push(`line-clamp-${ellipsisLines}`);
+  if (className) classes.push(className);
+  return (
+    <code className={classes.join(' ')} {...rest}>
+      {children}
+    </code>
+  );
+};
+
+export default InlineCode;

--- a/my-app/src/library/components/typography/Link.tsx
+++ b/my-app/src/library/components/typography/Link.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string;
+  external?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
+  truncate?: boolean;
+  ellipsisLines?: number;
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+};
+
+const weightClasses: Record<NonNullable<Props['weight']>, string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const Link: React.FC<Props> = ({
+  href,
+  external,
+  size = 'md',
+  weight = 'normal',
+  truncate,
+  ellipsisLines,
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = [sizeClasses[size], weightClasses[weight]];
+  if (truncate) classes.push('truncate');
+  if (ellipsisLines) classes.push(`line-clamp-${ellipsisLines}`);
+  if (className) classes.push(className);
+  return (
+    <a
+      href={href}
+      className={classes.join(' ')}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+};
+
+export default Link;

--- a/my-app/src/library/components/typography/Paragraph.tsx
+++ b/my-app/src/library/components/typography/Paragraph.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface Props extends React.HTMLAttributes<HTMLParagraphElement> {
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
+  truncate?: boolean;
+  ellipsisLines?: number;
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+};
+
+const weightClasses: Record<NonNullable<Props['weight']>, string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const Paragraph: React.FC<Props> = ({
+  size = 'md',
+  weight = 'normal',
+  truncate,
+  ellipsisLines,
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = [sizeClasses[size], weightClasses[weight]];
+  if (truncate) classes.push('truncate');
+  if (ellipsisLines) classes.push(`line-clamp-${ellipsisLines}`);
+  if (className) classes.push(className);
+  return (
+    <p className={classes.join(' ')} {...rest}>
+      {children}
+    </p>
+  );
+};
+
+export default Paragraph;

--- a/my-app/src/library/components/typography/Text.tsx
+++ b/my-app/src/library/components/typography/Text.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export interface Props extends React.HTMLAttributes<HTMLParagraphElement> {
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
+  truncate?: boolean;
+  ellipsisLines?: number;
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+};
+
+const weightClasses: Record<NonNullable<Props['weight']>, string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const Text: React.FC<Props> = ({
+  size = 'md',
+  weight = 'normal',
+  truncate,
+  ellipsisLines,
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = [sizeClasses[size], weightClasses[weight]];
+  if (truncate) classes.push('truncate');
+  if (ellipsisLines) classes.push(`line-clamp-${ellipsisLines}`);
+  if (className) classes.push(className);
+
+  return (
+    <p className={classes.join(' ')} {...rest}>
+      {children}
+    </p>
+  );
+};
+
+export default Text;

--- a/my-app/src/library/components/typography/index.ts
+++ b/my-app/src/library/components/typography/index.ts
@@ -1,0 +1,6 @@
+export * from './Text';
+export * from './Heading';
+export * from './Paragraph';
+export * from './Link';
+export * from './CodeBlock';
+export * from './InlineCode';

--- a/my-app/src/library/stories/CodeBlock.stories.tsx
+++ b/my-app/src/library/stories/CodeBlock.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CodeBlock } from '../components/typography/CodeBlock';
+
+const meta: Meta<typeof CodeBlock> = {
+  title: 'library/CodeBlock',
+  component: CodeBlock,
+  args: {
+    children: 'const a = 1;',
+    size: 'md',
+    weight: 'normal',
+    truncate: false,
+    ellipsisLines: 1,
+  },
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    weight: { control: { type: 'select' }, options: ['normal', 'semibold', 'bold'] },
+    truncate: { control: 'boolean' },
+    ellipsisLines: { control: 'number' },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof CodeBlock> = {};

--- a/my-app/src/library/stories/Heading.stories.tsx
+++ b/my-app/src/library/stories/Heading.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Heading } from '../components/typography/Heading';
+
+const meta: Meta<typeof Heading> = {
+  title: 'library/Heading',
+  component: Heading,
+  args: {
+    children: 'Heading',
+    level: 1,
+    size: 'md',
+    weight: 'normal',
+    truncate: false,
+    ellipsisLines: 1,
+  },
+  argTypes: {
+    level: { control: { type: 'number', min: 1, max: 6 } },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    weight: { control: { type: 'select' }, options: ['normal', 'semibold', 'bold'] },
+    truncate: { control: 'boolean' },
+    ellipsisLines: { control: 'number' },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof Heading> = {};

--- a/my-app/src/library/stories/InlineCode.stories.tsx
+++ b/my-app/src/library/stories/InlineCode.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { InlineCode } from '../components/typography/InlineCode';
+
+const meta: Meta<typeof InlineCode> = {
+  title: 'library/InlineCode',
+  component: InlineCode,
+  args: {
+    children: 'inline code',
+    size: 'md',
+    weight: 'normal',
+    truncate: false,
+    ellipsisLines: 1,
+  },
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    weight: { control: { type: 'select' }, options: ['normal', 'semibold', 'bold'] },
+    truncate: { control: 'boolean' },
+    ellipsisLines: { control: 'number' },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof InlineCode> = {};

--- a/my-app/src/library/stories/Link.stories.tsx
+++ b/my-app/src/library/stories/Link.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Link } from '../components/typography/Link';
+
+const meta: Meta<typeof Link> = {
+  title: 'library/Link',
+  component: Link,
+  args: {
+    children: 'Link text',
+    href: '#',
+    external: false,
+    size: 'md',
+    weight: 'normal',
+    truncate: false,
+    ellipsisLines: 1,
+  },
+  argTypes: {
+    href: { control: 'text' },
+    external: { control: 'boolean' },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    weight: { control: { type: 'select' }, options: ['normal', 'semibold', 'bold'] },
+    truncate: { control: 'boolean' },
+    ellipsisLines: { control: 'number' },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof Link> = {};

--- a/my-app/src/library/stories/Paragraph.stories.tsx
+++ b/my-app/src/library/stories/Paragraph.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Paragraph } from '../components/typography/Paragraph';
+
+const meta: Meta<typeof Paragraph> = {
+  title: 'library/Paragraph',
+  component: Paragraph,
+  args: {
+    children: 'Paragraph',
+    size: 'md',
+    weight: 'normal',
+    truncate: false,
+    ellipsisLines: 1,
+  },
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    weight: { control: { type: 'select' }, options: ['normal', 'semibold', 'bold'] },
+    truncate: { control: 'boolean' },
+    ellipsisLines: { control: 'number' },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof Paragraph> = {};

--- a/my-app/src/library/stories/Text.stories.tsx
+++ b/my-app/src/library/stories/Text.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Text } from '../components/typography/Text';
+
+const meta: Meta<typeof Text> = {
+  title: 'library/Text',
+  component: Text,
+  args: {
+    children: 'Sample text',
+    size: 'md',
+    weight: 'normal',
+    truncate: false,
+    ellipsisLines: 1,
+  },
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    weight: { control: { type: 'select' }, options: ['normal', 'semibold', 'bold'] },
+    truncate: { control: 'boolean' },
+    ellipsisLines: { control: 'number' },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof Text> = {};

--- a/my-app/src/library/tests/CodeBlock.test.tsx
+++ b/my-app/src/library/tests/CodeBlock.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { CodeBlock } from '../components/typography/CodeBlock';
+
+describe('CodeBlock', () => {
+  it('renders pre and code tags', () => {
+    const { container } = render(<CodeBlock>code</CodeBlock>);
+    expect(container.querySelector('pre')).toBeInTheDocument();
+    expect(container.querySelector('pre code')).toBeInTheDocument();
+  });
+
+  it('applies classes', () => {
+    const { container } = render(
+      <CodeBlock size="lg" weight="bold" truncate ellipsisLines={4} className="x">
+        code
+      </CodeBlock>
+    );
+    const pre = container.querySelector('pre') as HTMLElement;
+    expect(pre.className).toContain('text-lg');
+    expect(pre.className).toContain('font-bold');
+    expect(pre.className).toContain('truncate');
+    expect(pre.className).toContain('line-clamp-4');
+    expect(pre.className).toContain('x');
+  });
+});

--- a/my-app/src/library/tests/Heading.test.tsx
+++ b/my-app/src/library/tests/Heading.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import { Heading } from '../components/typography/Heading';
+
+describe('Heading', () => {
+  it('renders correct heading level', () => {
+    const { container } = render(<Heading level={2}>content</Heading>);
+    expect(container.querySelector('h2')).toBeInTheDocument();
+  });
+
+  it('applies classes', () => {
+    const { container } = render(
+      <Heading level={3} size="lg" weight="bold" truncate ellipsisLines={3} className="ex">
+        content
+      </Heading>
+    );
+    const el = container.querySelector('h3') as HTMLElement;
+    expect(el.className).toContain('text-lg');
+    expect(el.className).toContain('font-bold');
+    expect(el.className).toContain('truncate');
+    expect(el.className).toContain('line-clamp-3');
+    expect(el.className).toContain('ex');
+  });
+});

--- a/my-app/src/library/tests/InlineCode.test.tsx
+++ b/my-app/src/library/tests/InlineCode.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import { InlineCode } from '../components/typography/InlineCode';
+
+describe('InlineCode', () => {
+  it('renders code tag', () => {
+    const { container } = render(<InlineCode>inline</InlineCode>);
+    expect(container.querySelector('code')).toBeInTheDocument();
+  });
+
+  it('applies classes', () => {
+    const { container } = render(
+      <InlineCode size="sm" weight="semibold" truncate ellipsisLines={2} className="c">
+        inline
+      </InlineCode>
+    );
+    const code = container.querySelector('code') as HTMLElement;
+    expect(code.className).toContain('text-sm');
+    expect(code.className).toContain('font-semibold');
+    expect(code.className).toContain('truncate');
+    expect(code.className).toContain('line-clamp-2');
+    expect(code.className).toContain('c');
+  });
+});

--- a/my-app/src/library/tests/Link.test.tsx
+++ b/my-app/src/library/tests/Link.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import { Link } from '../components/typography/Link';
+
+describe('Link', () => {
+  it('renders anchor tag with href', () => {
+    const { getByText } = render(<Link href="/home">Home</Link>);
+    const anchor = getByText('Home');
+    expect(anchor.tagName.toLowerCase()).toBe('a');
+    expect(anchor).toHaveAttribute('href', '/home');
+  });
+
+  it('handles external links', () => {
+    const { getByText } = render(
+      <Link href="https://example.com" external>
+        External
+      </Link>
+    );
+    const anchor = getByText('External');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/my-app/src/library/tests/Paragraph.test.tsx
+++ b/my-app/src/library/tests/Paragraph.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { Paragraph } from '../components/typography/Paragraph';
+
+describe('Paragraph', () => {
+  it('renders p tag', () => {
+    const { container } = render(<Paragraph>para</Paragraph>);
+    expect(container.querySelector('p')).toBeInTheDocument();
+  });
+
+  it('applies classes', () => {
+    const { container } = render(
+      <Paragraph size="sm" weight="semibold" truncate ellipsisLines={1} className="c" />
+    );
+    const el = container.querySelector('p') as HTMLElement;
+    expect(el.className).toContain('text-sm');
+    expect(el.className).toContain('font-semibold');
+    expect(el.className).toContain('truncate');
+    expect(el.className).toContain('line-clamp-1');
+    expect(el.className).toContain('c');
+  });
+});

--- a/my-app/src/library/tests/Text.test.tsx
+++ b/my-app/src/library/tests/Text.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import { Text } from '../components/typography/Text';
+
+describe('Text', () => {
+  it('renders p tag', () => {
+    const { container } = render(<Text>content</Text>);
+    expect(container.querySelector('p')).toBeInTheDocument();
+  });
+
+  it('applies classes', () => {
+    const { container } = render(
+      <Text size="lg" weight="bold" truncate ellipsisLines={2} className="extra">
+        content
+      </Text>
+    );
+    const el = container.querySelector('p') as HTMLElement;
+    expect(el.className).toContain('text-lg');
+    expect(el.className).toContain('font-bold');
+    expect(el.className).toContain('truncate');
+    expect(el.className).toContain('line-clamp-2');
+    expect(el.className).toContain('extra');
+  });
+});


### PR DESCRIPTION
## Summary
- add a full set of Typography components under `src/library`
- implement Text, Heading, Paragraph, Link, CodeBlock and InlineCode with typed props
- provide Storybook stories for each component with controls
- create Jest tests for component behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0a10d0b083218cd0ac01bf7b2586