### PR TITLE
Add form input components

### DIFF
--- a/my-app/src/library/components/inputs/Input.tsx
+++ b/my-app/src/library/components/inputs/Input.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import {
+  Control,
+  Controller,
+  FieldValues,
+  RegisterOptions,
+  useFormContext,
+} from 'react-hook-form';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  name: string;
+  label?: string;
+  rules?: RegisterOptions;
+  control?: Control<FieldValues>;
+  className?: string;
+  variant?: 'outline' | 'filled';
+  size?: 'sm' | 'md' | 'lg';
+  theme?: 'light' | 'dark';
+}
+
+const sizeClasses: Record<NonNullable<InputProps['size']>, string> = {
+  sm: 'text-sm px-2 py-1',
+  md: 'text-base px-3 py-2',
+  lg: 'text-lg px-4 py-3',
+};
+
+const variantClasses: Record<NonNullable<InputProps['variant']>, string> = {
+  outline: 'bg-white border border-gray-300',
+  filled: 'bg-gray-100 border border-gray-300',
+};
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input(
+  {
+    name,
+    label,
+    placeholder,
+    rules,
+    control,
+    className,
+    variant = 'outline',
+    size = 'md',
+    theme = 'light',
+    ...rest
+  },
+  ref,
+) {
+  const [uncontrolledValue, setValue] = useState(rest.defaultValue || '');
+  let methods: ReturnType<typeof useFormContext<FieldValues>> | undefined;
+  try {
+    methods = useFormContext<FieldValues>();
+  } catch {
+    // not inside form provider
+  }
+
+  const inputClasses = clsx(
+    'rounded focus:outline-none focus:ring-2',
+    sizeClasses[size],
+    variantClasses[variant],
+    theme === 'dark'
+      ? 'bg-gray-800 text-white border-gray-700 focus:ring-blue-400'
+      : 'focus:ring-blue-500',
+    className,
+  );
+
+  const renderField = (
+    field: any,
+    fieldState?: { error?: { message?: string } | undefined },
+  ) => (
+    <div className="mb-4">
+      {label && (
+        <label htmlFor={name} className="block mb-1">
+          {label}
+        </label>
+      )}
+      <motion.input
+        id={name}
+        placeholder={placeholder}
+        whileFocus={{ scale: 1.02 }}
+        whileHover={{ scale: 1.01 }}
+        aria-invalid={fieldState?.error ? 'true' : 'false'}
+        aria-describedby={`${name}-error`}
+        className={inputClasses}
+        {...field}
+        {...rest}
+        ref={ref as any}
+      />
+      {fieldState?.error && (
+        <p id={`${name}-error`} role="alert" className="text-red-600 text-sm mt-1">
+          {fieldState.error.message}
+        </p>
+      )}
+    </div>
+  );
+
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field, fieldState }) =>
+          renderField(field, fieldState)
+        }
+      />
+    );
+  }
+
+  if (methods) {
+    const { ref: rf, ...reg } = methods.register(name, rules);
+    return renderField({ ...reg, ref: (el: HTMLInputElement) => {
+      rf(el);
+      if (typeof ref === 'function') ref(el);
+      else if (ref) (ref as React.MutableRefObject<HTMLInputElement | null>).current = el;
+    } });
+  }
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    rest.onChange?.(e);
+    if (rest.value === undefined) {
+      setValue(e.target.value);
+    }
+  };
+  return renderField({
+    name,
+    onChange: handleChange,
+    value: rest.value !== undefined ? rest.value : uncontrolledValue,
+    ref,
+  });
+});
+
+export default Input;

--- a/my-app/src/library/components/inputs/PasswordInput.tsx
+++ b/my-app/src/library/components/inputs/PasswordInput.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Input, InputProps } from './Input';
+
+export type PasswordInputProps = Omit<InputProps, 'type'>;
+
+export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  function PasswordInput(props, ref) {
+    return <Input type="password" {...props} ref={ref} />;
+  },
+);
+
+export default PasswordInput;

--- a/my-app/src/library/components/inputs/Textarea.tsx
+++ b/my-app/src/library/components/inputs/Textarea.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import {
+  Control,
+  Controller,
+  FieldValues,
+  RegisterOptions,
+  useFormContext,
+} from 'react-hook-form';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+
+export interface TextareaProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'> {
+  name: string;
+  label?: string;
+  rules?: RegisterOptions;
+  control?: Control<FieldValues>;
+  className?: string;
+  variant?: 'outline' | 'filled';
+  size?: 'sm' | 'md' | 'lg';
+  theme?: 'light' | 'dark';
+}
+
+const sizeClasses: Record<NonNullable<TextareaProps['size']>, string> = {
+  sm: 'text-sm px-2 py-1',
+  md: 'text-base px-3 py-2',
+  lg: 'text-lg px-4 py-3',
+};
+
+const variantClasses: Record<NonNullable<TextareaProps['variant']>, string> = {
+  outline: 'bg-white border border-gray-300',
+  filled: 'bg-gray-100 border border-gray-300',
+};
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  function Textarea(
+    {
+      name,
+      label,
+      placeholder,
+      rules,
+      control,
+      className,
+      variant = 'outline',
+      size = 'md',
+      theme = 'light',
+      ...rest
+    },
+    ref,
+  ) {
+    const [uncontrolledValue, setValue] = useState(rest.defaultValue || '');
+    let methods: ReturnType<typeof useFormContext<FieldValues>> | undefined;
+    try {
+      methods = useFormContext<FieldValues>();
+    } catch {
+      // not inside form provider
+    }
+
+    const inputClasses = clsx(
+      'rounded focus:outline-none focus:ring-2',
+      sizeClasses[size],
+      variantClasses[variant],
+      theme === 'dark'
+        ? 'bg-gray-800 text-white border-gray-700 focus:ring-blue-400'
+        : 'focus:ring-blue-500',
+      className,
+    );
+
+    const renderField = (
+      field: any,
+      fieldState?: { error?: { message?: string } | undefined },
+    ) => (
+      <div className="mb-4">
+        {label && (
+          <label htmlFor={name} className="block mb-1">
+            {label}
+          </label>
+        )}
+        <motion.textarea
+          id={name}
+          placeholder={placeholder}
+          whileFocus={{ scale: 1.02 }}
+          whileHover={{ scale: 1.01 }}
+          aria-invalid={fieldState?.error ? 'true' : 'false'}
+          aria-describedby={`${name}-error`}
+          className={inputClasses}
+          {...field}
+          {...rest}
+          ref={ref as any}
+        />
+        {fieldState?.error && (
+          <p id={`${name}-error`} role="alert" className="text-red-600 text-sm mt-1">
+            {fieldState.error.message}
+          </p>
+        )}
+      </div>
+    );
+
+    if (control) {
+      return (
+        <Controller
+          name={name}
+          control={control}
+          rules={rules}
+          render={({ field, fieldState }) =>
+            renderField(field, fieldState)
+          }
+        />
+      );
+    }
+
+    if (methods) {
+      const { ref: rf, ...reg } = methods.register(name, rules);
+      return renderField({ ...reg, ref: (el: HTMLTextAreaElement) => {
+        rf(el);
+        if (typeof ref === 'function') ref(el);
+        else if (ref) (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current = el;
+      } });
+    }
+
+    const handleChange = (
+      e: React.ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      rest.onChange?.(e);
+      if (rest.value === undefined) {
+        setValue(e.target.value);
+      }
+    };
+    return renderField({
+      name,
+      onChange: handleChange,
+      value: rest.value !== undefined ? rest.value : uncontrolledValue,
+      ref,
+    });
+  },
+);
+
+export default Textarea;

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,3 @@
+export * from './Input';
+export * from './PasswordInput';
+export * from './Textarea';

--- a/my-app/src/library/stories/inputs/Input.stories.tsx
+++ b/my-app/src/library/stories/inputs/Input.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from '../../components/inputs/Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'library/Inputs/Input',
+  component: Input,
+  args: {
+    name: 'field',
+    label: 'Label',
+    placeholder: 'Enter text',
+    variant: 'outline',
+    size: 'md',
+  },
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    rules: { control: 'object' },
+    variant: { control: 'select', options: ['outline', 'filled'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof Input> = {};

--- a/my-app/src/library/stories/inputs/PasswordInput.stories.tsx
+++ b/my-app/src/library/stories/inputs/PasswordInput.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PasswordInput } from '../../components/inputs/PasswordInput';
+
+const meta: Meta<typeof PasswordInput> = {
+  title: 'library/Inputs/PasswordInput',
+  component: PasswordInput,
+  args: {
+    name: 'password',
+    label: 'Password',
+    placeholder: 'Enter password',
+    variant: 'outline',
+    size: 'md',
+  },
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    rules: { control: 'object' },
+    variant: { control: 'select', options: ['outline', 'filled'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof PasswordInput> = {};

--- a/my-app/src/library/stories/inputs/Textarea.stories.tsx
+++ b/my-app/src/library/stories/inputs/Textarea.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Textarea } from '../../components/inputs/Textarea';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'library/Inputs/Textarea',
+  component: Textarea,
+  args: {
+    name: 'area',
+    label: 'Textarea',
+    placeholder: 'Enter text',
+    variant: 'outline',
+    size: 'md',
+  },
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    rules: { control: 'object' },
+    variant: { control: 'select', options: ['outline', 'filled'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+  },
+};
+export default meta;
+export const Default: StoryObj<typeof Textarea> = {};

--- a/my-app/src/library/tests/Input.test.tsx
+++ b/my-app/src/library/tests/Input.test.tsx
@@ -1,0 +1,42 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { Input } from '../components/inputs/Input';
+import { FormProvider, useForm } from 'react-hook-form';
+
+function withForm(children: React.ReactNode) {
+  const Wrapper = () => {
+    const methods = useForm<{ field: string }>({ mode: 'onBlur' });
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  };
+  return Wrapper;
+}
+
+describe('Input', () => {
+  it('renders label', () => {
+    const { getByLabelText } = render(<Input name="field" label="Label" />);
+    expect(getByLabelText('Label')).toBeInTheDocument();
+  });
+
+  it('calls onChange', () => {
+    const handle = jest.fn();
+    const { getByLabelText } = render(
+      <Input name="field" label="Label" onChange={handle} />,
+    );
+    fireEvent.change(getByLabelText('Label'), { target: { value: 'x' } });
+    expect(handle).toHaveBeenCalled();
+  });
+
+  it('shows validation error', async () => {
+    const Wrapper = withForm(
+      <Input
+        name="field"
+        label="Label"
+        rules={{ required: 'required' }}
+      />,
+    );
+    const { getByLabelText, getByText } = render(<Wrapper />);
+    fireEvent.blur(getByLabelText('Label'));
+    await waitFor(() => {
+      expect(getByText('required')).toBeInTheDocument();
+    });
+  });
+});

--- a/my-app/src/library/tests/PasswordInput.test.tsx
+++ b/my-app/src/library/tests/PasswordInput.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import { PasswordInput } from '../components/inputs/PasswordInput';
+
+describe('PasswordInput', () => {
+  it('renders password type', () => {
+    const { getByLabelText } = render(
+      <PasswordInput name="pwd" label="Password" />,
+    );
+    const input = getByLabelText('Password') as HTMLInputElement;
+    expect(input.type).toBe('password');
+  });
+});

--- a/my-app/src/library/tests/Textarea.test.tsx
+++ b/my-app/src/library/tests/Textarea.test.tsx
@@ -1,0 +1,31 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { Textarea } from '../components/inputs/Textarea';
+import { FormProvider, useForm } from 'react-hook-form';
+
+function withForm(children: React.ReactNode) {
+  const Wrapper = () => {
+    const methods = useForm<{ field: string }>({ mode: 'onBlur' });
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  };
+  return Wrapper;
+}
+
+describe('Textarea', () => {
+  it('renders label', () => {
+    const { getByLabelText } = render(
+      <Textarea name="field" label="Area" />,
+    );
+    expect(getByLabelText('Area')).toBeInTheDocument();
+  });
+
+  it('shows validation error', async () => {
+    const Wrapper = withForm(
+      <Textarea name="field" label="Area" rules={{ required: 'req' }} />,
+    );
+    const { getByLabelText, getByText } = render(<Wrapper />);
+    fireEvent.blur(getByLabelText('Area'));
+    await waitFor(() => {
+      expect(getByText('req')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add generic Input, PasswordInput and Textarea components with optional RHF support
- provide Storybook stories
- add Jest tests for the new inputs

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0ffcb0b08321b92208b15e510647