### PR TITLE
Add Button and IconButton components

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,2 @@
 export * from './primitives';
+export * from './inputs';

--- a/my-app/src/library/components/inputs/Button.tsx
+++ b/my-app/src/library/components/inputs/Button.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+import { useTheme } from '../../hooks/useTheme';
+
+export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  isLoading?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  className?: string;
+  analyticsKey?: string;
+}
+
+const variantClasses: Record<NonNullable<Props['variant']>, string> = {
+  primary:
+    'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600',
+  secondary:
+    'bg-gray-200 text-gray-900 hover:bg-gray-300 disabled:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600',
+  ghost:
+    'bg-transparent text-blue-600 hover:bg-blue-50 disabled:text-blue-300 dark:text-blue-400 dark:hover:bg-gray-700',
+};
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'px-2 py-1 text-sm',
+  md: 'px-4 py-2',
+  lg: 'px-6 py-3 text-lg',
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, Props>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    isLoading = false,
+    leftIcon,
+    rightIcon,
+    className,
+    analyticsKey,
+    disabled,
+    children,
+    onClick,
+    ...rest
+  },
+  ref,
+) {
+  useTheme(); // subscribe to theme changes
+  const classes = clsx(
+    'inline-flex items-center justify-center rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2',
+    variantClasses[variant],
+    sizeClasses[size],
+    className,
+  );
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (isLoading || disabled) {
+      e.preventDefault();
+      return;
+    }
+    onClick?.(e);
+  };
+
+  const MotionButton = motion.button;
+
+  return (
+    <MotionButton
+      ref={ref}
+      type="button"
+      className={classes}
+      data-analytics={analyticsKey}
+      aria-busy={isLoading}
+      aria-disabled={isLoading || disabled}
+      disabled={isLoading || disabled}
+      whileTap={{ scale: 0.97 }}
+      onClick={handleClick}
+      {...rest}
+    >
+      {isLoading ? (
+        <svg
+          className="animate-spin h-4 w-4 mr-2 text-current"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+            fill="none"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          />
+        </svg>
+      ) : (
+        leftIcon && <span className="mr-2">{leftIcon}</span>
+      )}
+      <span>{children}</span>
+      {rightIcon && <span className="ml-2">{rightIcon}</span>}
+    </MotionButton>
+  );
+});

--- a/my-app/src/library/components/inputs/IconButton.tsx
+++ b/my-app/src/library/components/inputs/IconButton.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+import { useTheme } from '../../hooks/useTheme';
+
+export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  isLoading?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  className?: string;
+  analyticsKey?: string;
+}
+
+const variantClasses: Record<NonNullable<Props['variant']>, string> = {
+  primary:
+    'bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600',
+  secondary:
+    'bg-gray-200 text-gray-900 hover:bg-gray-300 disabled:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600',
+  ghost:
+    'bg-transparent text-blue-600 hover:bg-blue-50 disabled:text-blue-300 dark:text-blue-400 dark:hover:bg-gray-700',
+};
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'p-1 text-sm',
+  md: 'p-2',
+  lg: 'p-3 text-lg',
+};
+
+export const IconButton = React.forwardRef<HTMLButtonElement, Props>(function IconButton(
+  {
+    variant = 'primary',
+    size = 'md',
+    isLoading = false,
+    leftIcon,
+    rightIcon,
+    className,
+    analyticsKey,
+    disabled,
+    children,
+    onClick,
+    ...rest
+  },
+  ref,
+) {
+  useTheme();
+  const classes = clsx(
+    'inline-flex items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2',
+    variantClasses[variant],
+    sizeClasses[size],
+    className,
+  );
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (isLoading || disabled) {
+      e.preventDefault();
+      return;
+    }
+    onClick?.(e);
+  };
+
+  const MotionButton = motion.button;
+
+  return (
+    <MotionButton
+      ref={ref}
+      type="button"
+      className={classes}
+      data-analytics={analyticsKey}
+      aria-busy={isLoading}
+      aria-disabled={isLoading || disabled}
+      disabled={isLoading || disabled}
+      whileTap={{ scale: 0.97 }}
+      onClick={handleClick}
+      {...rest}
+    >
+      {isLoading ? (
+        <svg
+          className="animate-spin h-4 w-4 text-current"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+            fill="none"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          />
+        </svg>
+      ) : (
+        <>{leftIcon || children || rightIcon}</>
+      )}
+    </MotionButton>
+  );
+});

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,2 @@
+export * from './Button';
+export * from './IconButton';

--- a/my-app/src/library/hooks/useTheme.ts
+++ b/my-app/src/library/hooks/useTheme.ts
@@ -1,0 +1,4 @@
+import { useThemeStore } from '@app/stores/useThemeStore';
+
+/** Returns the current theme mode */
+export const useTheme = () => useThemeStore((s) => s.theme);

--- a/my-app/src/library/stories/Button.stories.tsx
+++ b/my-app/src/library/stories/Button.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button, Props } from '../components/inputs/Button';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/Button',
+  component: Button,
+  args: {
+    children: 'Button',
+    variant: 'primary',
+    size: 'md',
+    isLoading: false,
+  },
+  argTypes: {
+    variant: { control: { type: 'select' }, options: ['primary', 'secondary', 'ghost'] },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    isLoading: { control: 'boolean' },
+    leftIcon: { control: 'text' },
+    rightIcon: { control: 'text' },
+    className: { control: 'text' },
+    analyticsKey: { control: 'text' },
+  },
+};
+export default meta;
+export const Default: StoryObj<Props> = {};
+export const Loading: StoryObj<Props> = { args: { isLoading: true } };
+export const WithIcons: StoryObj<Props> = { args: { leftIcon: '⬅️', rightIcon: '➡️' } };

--- a/my-app/src/library/stories/IconButton.stories.tsx
+++ b/my-app/src/library/stories/IconButton.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconButton, Props } from '../components/inputs/IconButton';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/IconButton',
+  component: IconButton,
+  args: {
+    children: '⭐',
+    variant: 'primary',
+    size: 'md',
+    isLoading: false,
+  },
+  argTypes: {
+    variant: { control: { type: 'select' }, options: ['primary', 'secondary', 'ghost'] },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    isLoading: { control: 'boolean' },
+    leftIcon: { control: 'text' },
+    rightIcon: { control: 'text' },
+    className: { control: 'text' },
+    analyticsKey: { control: 'text' },
+  },
+};
+export default meta;
+export const Default: StoryObj<Props> = {};
+export const Loading: StoryObj<Props> = { args: { isLoading: true } };

--- a/my-app/src/library/tests/Button.test.tsx
+++ b/my-app/src/library/tests/Button.test.tsx
@@ -1,0 +1,24 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Button } from '../components/inputs/Button';
+
+describe('Button', () => {
+  it('applies variant and size classes', () => {
+    const { getByRole } = render(
+      <Button variant="secondary" size="sm">Click</Button>
+    );
+    const btn = getByRole('button');
+    expect(btn.className).toContain('bg-gray-200');
+    expect(btn.className).toContain('px-2');
+  });
+
+  it('shows loading state and disables click', () => {
+    const onClick = jest.fn();
+    const { getByRole } = render(
+      <Button isLoading onClick={onClick}>Load</Button>
+    );
+    const btn = getByRole('button');
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/my-app/src/library/tests/IconButton.test.tsx
+++ b/my-app/src/library/tests/IconButton.test.tsx
@@ -1,0 +1,23 @@
+import { render, fireEvent } from '@testing-library/react';
+import { IconButton } from '../components/inputs/IconButton';
+
+describe('IconButton', () => {
+  it('applies classes', () => {
+    const { getByRole } = render(
+      <IconButton variant="ghost" size="lg">I</IconButton>
+    );
+    const btn = getByRole('button');
+    expect(btn.className).toContain('bg-transparent');
+    expect(btn.className).toContain('p-3');
+  });
+
+  it('suppresses click when loading', () => {
+    const onClick = jest.fn();
+    const { getByRole } = render(
+      <IconButton isLoading onClick={onClick}>I</IconButton>
+    );
+    const btn = getByRole('button');
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `Button` and `IconButton` components with variant/size mappings
- include a `useTheme` hook
- expose new components through component index
- add tests for new buttons
- provide storybook stories for Button and IconButton

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a0ff0082c832194ff8372f486bf8c