### PR TITLE
Add inputs components with RHF

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,2 @@
 export * from './primitives';
+export * from './inputs';

--- a/my-app/src/library/components/inputs/Checkbox.tsx
+++ b/my-app/src/library/components/inputs/Checkbox.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { Controller, Control, FieldValues, FieldPath, RegisterOptions } from 'react-hook-form';
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+
+export interface Option {
+  value: string | number;
+  label: string;
+}
+
+export interface CheckboxProps<T extends FieldValues = FieldValues> {
+  name: FieldPath<T>;
+  label?: string;
+  options?: Option[];
+  value?: any;
+  defaultValue?: any;
+  onChange?: (value: any) => void;
+  rules?: RegisterOptions;
+  control?: Control<T>;
+  multiple?: boolean;
+  className?: string;
+  variant?: 'outline' | 'filled';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClasses: Record<string, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+};
+
+export const Checkbox = React.forwardRef(function Checkbox<T extends FieldValues>(
+  {
+    control,
+    name,
+    rules,
+    options,
+    value,
+    defaultValue,
+    onChange,
+    multiple = false,
+    label,
+    className,
+    size = 'md',
+  }: CheckboxProps<T>,
+  ref: React.Ref<HTMLInputElement>,
+) {
+  const renderInput = (
+    checkedValue: any,
+    handleChange: (val: any) => void,
+    fieldRef?: (el: HTMLInputElement | null) => void,
+    invalid?: boolean,
+  ) => {
+    if (options && multiple) {
+      return (
+        <div className={clsx('space-y-2', className)} role="group">
+          {options.map(opt => (
+            <motion.label
+              whileHover={{ scale: 1.02 }}
+              key={opt.value}
+              className="flex items-center space-x-2"
+            >
+              <input
+                ref={fieldRef}
+                type="checkbox"
+                value={opt.value}
+                checked={checkedValue?.includes(opt.value)}
+                onChange={e => {
+                  const val = e.target.value;
+                  let newVal = Array.isArray(checkedValue) ? [...checkedValue] : [];
+                  if (e.target.checked) newVal.push(val);
+                  else newVal = newVal.filter(v => v !== val);
+                  handleChange(newVal);
+                }}
+                role="checkbox"
+                aria-checked={checkedValue?.includes(opt.value)}
+                aria-invalid={invalid}
+                className={clsx('rounded border-gray-300 text-blue-600', sizeClasses[size])}
+              />
+              <span>{opt.label}</span>
+            </motion.label>
+          ))}
+        </div>
+      );
+    }
+    return (
+      <label className={clsx('inline-flex items-center space-x-2', className)}>
+        <input
+          ref={fieldRef}
+          type="checkbox"
+          checked={!!checkedValue}
+          onChange={e => handleChange(e.target.checked)}
+          role="checkbox"
+          aria-checked={!!checkedValue}
+          aria-invalid={invalid}
+          className={clsx('rounded border-gray-300 text-blue-600', sizeClasses[size])}
+        />
+        {label && <span>{label}</span>}
+      </label>
+    );
+  };
+
+  if (control) {
+    return (
+      <Controller
+        control={control}
+        name={name}
+        rules={rules}
+        defaultValue={defaultValue as any}
+        render={({ field, fieldState }) =>
+          renderInput(
+            field.value,
+            val => {
+              field.onChange(val);
+              onChange?.(val);
+            },
+            el => {
+              field.ref(el);
+              if (typeof ref === 'function') ref(el);
+              else if (ref) (ref as any).current = el;
+            },
+            fieldState.invalid,
+          )
+        }
+      />
+    );
+  }
+
+  const [internal, setInternal] = useState(defaultValue ?? (multiple ? [] : false));
+
+  return renderInput(
+    value !== undefined ? value : internal,
+    val => {
+      if (value === undefined) setInternal(val);
+      onChange?.(val);
+    },
+    ref as any,
+    false,
+  );
+}) as <T extends FieldValues>(p: CheckboxProps<T> & { ref?: React.Ref<HTMLInputElement> }) => JSX.Element;
+

--- a/my-app/src/library/components/inputs/RadioGroup.tsx
+++ b/my-app/src/library/components/inputs/RadioGroup.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Controller, Control, FieldValues, FieldPath, RegisterOptions } from 'react-hook-form';
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+
+export interface Option {
+  value: string | number;
+  label: string;
+}
+
+export interface RadioGroupProps<T extends FieldValues = FieldValues> {
+  name: FieldPath<T>;
+  label?: string;
+  options: Option[];
+  value?: any;
+  defaultValue?: any;
+  onChange?: (value: any) => void;
+  rules?: RegisterOptions;
+  control?: Control<T>;
+  className?: string;
+  variant?: 'outline' | 'filled';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClasses: Record<string, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+};
+
+export const RadioGroup = React.forwardRef(function RadioGroup<T extends FieldValues>(
+  {
+    control,
+    name,
+    rules,
+    value,
+    defaultValue,
+    onChange,
+    options,
+    className,
+    size = 'md',
+  }: RadioGroupProps<T>,
+  ref: React.Ref<HTMLInputElement>,
+) {
+  const renderGroup = (
+    selected: any,
+    handleChange: (val: any) => void,
+    fieldRef?: (el: HTMLInputElement | null) => void,
+    invalid?: boolean,
+  ) => (
+    <div role="radiogroup" className={clsx('space-y-2', className)}>
+      {options.map(opt => (
+        <motion.label
+          key={opt.value}
+          whileHover={{ scale: 1.02 }}
+          className="flex items-center space-x-2"
+        >
+          <input
+            ref={fieldRef}
+            type="radio"
+            value={opt.value}
+            checked={selected === opt.value}
+            onChange={() => handleChange(opt.value)}
+            role="radio"
+            aria-checked={selected === opt.value}
+            aria-invalid={invalid}
+            className={clsx('text-blue-600', sizeClasses[size])}
+          />
+          <span>{opt.label}</span>
+        </motion.label>
+      ))}
+    </div>
+  );
+
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        defaultValue={defaultValue as any}
+        render={({ field, fieldState }) =>
+          renderGroup(
+            field.value,
+            val => {
+              field.onChange(val);
+              onChange?.(val);
+            },
+            el => {
+              field.ref(el);
+              if (typeof ref === 'function') ref(el);
+              else if (ref) (ref as any).current = el;
+            },
+            fieldState.invalid,
+          )
+        }
+      />
+    );
+  }
+
+  const [internal, setInternal] = React.useState(defaultValue);
+  return renderGroup(
+    value !== undefined ? value : internal,
+    val => {
+      if (value === undefined) setInternal(val);
+      onChange?.(val);
+    },
+    ref as any,
+    false,
+  );
+}) as <T extends FieldValues>(p: RadioGroupProps<T> & { ref?: React.Ref<HTMLInputElement> }) => JSX.Element;
+

--- a/my-app/src/library/components/inputs/Select.tsx
+++ b/my-app/src/library/components/inputs/Select.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { Controller, Control, FieldValues, FieldPath, RegisterOptions } from 'react-hook-form';
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+
+export interface Option {
+  value: string | number;
+  label: string;
+}
+
+export interface SelectProps<T extends FieldValues = FieldValues> {
+  name: FieldPath<T>;
+  label?: string;
+  options: Option[];
+  value?: any;
+  defaultValue?: any;
+  onChange?: (value: any) => void;
+  rules?: RegisterOptions;
+  control?: Control<T>;
+  multiple?: boolean;
+  className?: string;
+  variant?: 'outline' | 'filled';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClasses: Record<string, string> = {
+  sm: 'p-1 text-sm',
+  md: 'p-2',
+  lg: 'p-3 text-lg',
+};
+
+const variantClasses: Record<string, string> = {
+  outline: 'ring-1 ring-gray-300 focus:ring-blue-500',
+  filled: 'bg-gray-100 ring-1 ring-gray-300 focus:ring-blue-500',
+};
+
+function SelectElement(
+  {
+    label,
+    options,
+    value,
+    defaultValue,
+    onChange,
+    multiple,
+    className,
+    variant = 'outline',
+    size = 'md',
+    inputRef,
+  }: Omit<SelectProps, 'name' | 'rules' | 'control'> & { inputRef?: React.Ref<HTMLSelectElement> },
+) {
+  return (
+    <label className="block">
+      {label && <span className="mb-1 block">{label}</span>}
+      <select
+        ref={inputRef}
+        value={value}
+        defaultValue={defaultValue}
+        onChange={e => {
+          const val = multiple
+            ? Array.from(e.target.selectedOptions).map(o => o.value)
+            : e.target.value;
+          onChange?.(val);
+        }}
+        multiple={multiple}
+        className={clsx('rounded outline-none', variantClasses[variant], sizeClasses[size], className)}
+      >
+        {options.map(opt => (
+          <motion.option key={opt.value} value={opt.value} whileHover={{ scale: 1.05 }}>
+            {opt.label}
+          </motion.option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export const Select = React.forwardRef(function Select<T extends FieldValues>(
+  {
+    control,
+    name,
+    rules,
+    value,
+    defaultValue,
+    onChange,
+    ...rest
+  }: SelectProps<T>,
+  ref: React.Ref<HTMLSelectElement>,
+) {
+  if (control) {
+    return (
+      <Controller
+        control={control}
+        name={name}
+        rules={rules}
+        defaultValue={defaultValue as any}
+        render={({ field, fieldState }) => (
+          <SelectElement
+            {...rest}
+            value={field.value}
+            onChange={val => {
+              field.onChange(val);
+              onChange?.(val);
+            }}
+            inputRef={el => {
+              field.ref(el);
+              if (typeof ref === 'function') ref(el);
+              else if (ref) (ref as any).current = el;
+            }}
+            multiple={rest.multiple}
+            className={clsx(rest.className, fieldState.invalid && 'ring-red-500')}
+          />
+        )}
+      />
+    );
+  }
+
+  return (
+    <SelectElement
+      {...rest}
+      value={value}
+      defaultValue={defaultValue}
+      onChange={val => {
+        onChange?.(val);
+      }}
+      inputRef={ref}
+    />
+  );
+}) as <T extends FieldValues>(p: SelectProps<T> & { ref?: React.Ref<HTMLSelectElement> }) => JSX.Element;
+

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,3 @@
+export * from './Select';
+export * from './Checkbox';
+export * from './RadioGroup';

--- a/my-app/src/library/stories/Checkbox.stories.tsx
+++ b/my-app/src/library/stories/Checkbox.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Checkbox } from '../components/inputs/Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'library/Inputs/Checkbox',
+  component: Checkbox,
+  args: { name: 'check' },
+};
+export default meta;
+
+export const Default: StoryObj<typeof Checkbox> = {
+  args: { label: 'Check me' },
+};
+
+export const Group: StoryObj<typeof Checkbox> = {
+  args: {
+    multiple: true,
+    options: [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ],
+  },
+};

--- a/my-app/src/library/stories/RadioGroup.stories.tsx
+++ b/my-app/src/library/stories/RadioGroup.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RadioGroup } from '../components/inputs/RadioGroup';
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'library/Inputs/RadioGroup',
+  component: RadioGroup,
+  args: {
+    name: 'radio',
+    options: [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ],
+  },
+};
+export default meta;
+
+export const Horizontal: StoryObj<typeof RadioGroup> = {
+  args: {},
+};

--- a/my-app/src/library/stories/Select.stories.tsx
+++ b/my-app/src/library/stories/Select.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select } from '../components/inputs/Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'library/Inputs/Select',
+  component: Select,
+  args: {
+    name: 'select',
+    options: [
+      { value: 'a', label: 'Option A' },
+      { value: 'b', label: 'Option B' },
+    ],
+  },
+};
+export default meta;
+
+export const Single: StoryObj<typeof Select> = {
+  args: { label: 'Single Select' },
+};
+
+export const Multiple: StoryObj<typeof Select> = {
+  args: { multiple: true, label: 'Multi Select' },
+};

--- a/my-app/src/library/tests/Checkbox.test.tsx
+++ b/my-app/src/library/tests/Checkbox.test.tsx
@@ -1,0 +1,50 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Checkbox } from '../components/inputs/Checkbox';
+import { useForm } from 'react-hook-form';
+import React from 'react';
+
+describe('Checkbox', () => {
+  it('toggles when uncontrolled', () => {
+    const { getByRole } = render(<Checkbox name="c" label="C" defaultValue={false} />);
+    const input = getByRole('checkbox') as HTMLInputElement;
+    expect(input.checked).toBe(false);
+    fireEvent.click(input);
+    expect(input.checked).toBe(true);
+  });
+
+  it('supports controlled state', () => {
+    const Comp = () => {
+      const [val, setVal] = React.useState(false);
+      return <Checkbox name="c" label="C" value={val} onChange={setVal} />;
+    };
+    const { getByRole } = render(<Comp />);
+    const input = getByRole('checkbox') as HTMLInputElement;
+    fireEvent.click(input);
+    expect(input.checked).toBe(true);
+  });
+
+  it('works with react-hook-form', () => {
+    const form = useForm({ defaultValues: { c: false } });
+    const { getByRole } = render(<Checkbox name="c" control={form.control} label="C" />);
+    const input = getByRole('checkbox') as HTMLInputElement;
+    fireEvent.click(input);
+    expect(form.getValues('c')).toBe(true);
+  });
+
+  it('handles multiple options', () => {
+    const { getAllByRole } = render(
+      <Checkbox
+        name="g"
+        multiple
+        options={[
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' },
+        ]}
+        defaultValue={[]}
+      />,
+    );
+    const inputs = getAllByRole('checkbox') as HTMLInputElement[];
+    fireEvent.click(inputs[0]);
+    expect(inputs[0].checked).toBe(true);
+  });
+});

--- a/my-app/src/library/tests/RadioGroup.test.tsx
+++ b/my-app/src/library/tests/RadioGroup.test.tsx
@@ -1,0 +1,40 @@
+import { render, fireEvent } from '@testing-library/react';
+import { RadioGroup } from '../components/inputs/RadioGroup';
+import { useForm } from 'react-hook-form';
+import React from 'react';
+
+describe('RadioGroup', () => {
+  it('changes selection', () => {
+    const { getAllByRole } = render(
+      <RadioGroup
+        name="r"
+        options={[
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' },
+        ]}
+        defaultValue="a"
+      />,
+    );
+    const radios = getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[0].checked).toBe(true);
+    fireEvent.click(radios[1]);
+    expect(radios[1].checked).toBe(true);
+  });
+
+  it('works with react-hook-form', () => {
+    const form = useForm({ defaultValues: { r: 'a' } });
+    const { getAllByRole } = render(
+      <RadioGroup
+        name="r"
+        control={form.control}
+        options={[
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' },
+        ]}
+      />,
+    );
+    const radios = getAllByRole('radio') as HTMLInputElement[];
+    fireEvent.click(radios[1]);
+    expect(form.getValues('r')).toBe('b');
+  });
+});

--- a/my-app/src/library/tests/Select.test.tsx
+++ b/my-app/src/library/tests/Select.test.tsx
@@ -1,0 +1,52 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Select } from '../components/inputs/Select';
+import { useForm } from 'react-hook-form';
+import React from 'react';
+
+describe('Select', () => {
+  it('changes value when uncontrolled', () => {
+    const { getByRole } = render(
+      <Select
+        name="s"
+        options={[{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }]}
+        defaultValue="a"
+      />,
+    );
+    const select = getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('a');
+    fireEvent.change(select, { target: { value: 'b' } });
+    expect(select.value).toBe('b');
+  });
+
+  it('calls onChange in controlled mode', () => {
+    const Comp = () => {
+      const [val, setVal] = React.useState('a');
+      return (
+        <Select
+          name="c"
+          options={[{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }]}
+          value={val}
+          onChange={v => setVal(v)}
+        />
+      );
+    };
+    const { getByRole } = render(<Comp />);
+    const select = getByRole('combobox') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'b' } });
+    expect(select.value).toBe('b');
+  });
+
+  it('integrates with react-hook-form', () => {
+    const form = useForm({ defaultValues: { s: 'a' } });
+    const { getByRole } = render(
+      <Select
+        name="s"
+        control={form.control}
+        options={[{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }]}
+      />,
+    );
+    const select = getByRole('combobox') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'b' } });
+    expect(form.getValues('s')).toBe('b');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `Select`, `Checkbox` and `RadioGroup` components with React Hook Form support and framer-motion
- export new inputs in component index
- add unit tests covering controlled/uncontrolled and RHF usage
- provide Storybook stories for the new components

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1036534483219486a5804d6c7adc