### PR TITLE
Add ToggleSwitch & Slider inputs

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,3 @@
 export * from './primitives';
+export * from './typography';
+export * from './inputs';

--- a/my-app/src/library/components/inputs/Slider.tsx
+++ b/my-app/src/library/components/inputs/Slider.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useRef } from 'react';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+import { Controller, Control, FieldValues, RegisterOptions } from 'react-hook-form';
+
+export interface SliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  name: string;
+  value?: number;
+  defaultValue?: number;
+  onChange?: (value: number) => void;
+  rules?: RegisterOptions;
+  control?: Control<FieldValues>;
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+  color?: 'primary' | 'secondary';
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+const sizeTrack: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'h-1',
+  md: 'h-2',
+  lg: 'h-3',
+};
+const sizeThumb: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'w-3 h-3',
+  md: 'w-4 h-4',
+  lg: 'w-6 h-6',
+};
+const colorFill: Record<'primary' | 'secondary', string> = {
+  primary: 'bg-blue-600',
+  secondary: 'bg-green-600',
+};
+
+interface BaseProps extends SliderProps { }
+
+const BaseSlider = React.forwardRef<HTMLDivElement, BaseProps>(function BaseSlider(
+  {
+    name,
+    value,
+    defaultValue,
+    onChange,
+    className,
+    size = 'md',
+    color = 'primary',
+    min = 0,
+    max = 100,
+    step = 1,
+    ...rest
+  },
+  ref,
+) {
+  const [internal, setInternal] = useState(defaultValue ?? min);
+  const isControlled = typeof value === 'number';
+  const val = isControlled ? value : internal;
+  const trackRef = useRef<HTMLDivElement>(null);
+  const percent = ((val - min) / (max - min)) * 100;
+  const handleValue = (v: number) => {
+    let next = Math.min(Math.max(v, min), max);
+    next = Math.round(next / step) * step;
+    if (!isControlled) setInternal(next);
+    onChange?.(next);
+  };
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowRight') handleValue(val + step);
+    if (e.key === 'ArrowLeft') handleValue(val - step);
+  };
+  return (
+    <div
+      ref={ref}
+      role="slider"
+      tabIndex={0}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={val}
+      onKeyDown={handleKey}
+      className={clsx('relative w-full select-none', className)}
+      {...rest}
+    >
+      <div ref={trackRef} className={clsx('relative rounded-full bg-gray-300', sizeTrack[size])}>
+        <div
+          className={clsx('absolute left-0 top-0 rounded-full', colorFill[color], sizeTrack[size])}
+          style={{ width: `${percent}%` }}
+        />
+        <motion.div
+          className={clsx('absolute top-1/2 -translate-y-1/2 rounded-full bg-white shadow cursor-pointer', sizeThumb[size])}
+          drag="x"
+          dragConstraints={trackRef}
+          dragElastic={0}
+          animate={{ left: `${percent}%` }}
+          transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+          onDrag={(_, info) => {
+            if (!trackRef.current) return;
+            const rect = trackRef.current.getBoundingClientRect();
+            const pos = info.point.x - rect.left;
+            const perc = Math.min(Math.max(pos / rect.width, 0), 1);
+            handleValue(min + perc * (max - min));
+          }}
+        />
+      </div>
+      <input type="hidden" name={name} value={val} />
+    </div>
+  );
+});
+
+export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(function Slider(props, ref) {
+  const { control, rules, name, ...rest } = props;
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <BaseSlider
+            {...rest}
+            {...field}
+            value={field.value}
+            onChange={field.onChange}
+            ref={ref}
+            name={name}
+          />
+        )}
+      />
+    );
+  }
+  return <BaseSlider ref={ref} name={name} {...rest} />;
+});
+
+export default Slider;

--- a/my-app/src/library/components/inputs/ToggleSwitch.tsx
+++ b/my-app/src/library/components/inputs/ToggleSwitch.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+import { Controller, Control, FieldValues, RegisterOptions } from 'react-hook-form';
+
+export interface ToggleSwitchProps extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  name: string;
+  checked?: boolean;
+  defaultChecked?: boolean;
+  onChange?: (checked: boolean) => void;
+  rules?: RegisterOptions;
+  control?: Control<FieldValues>;
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+  color?: 'primary' | 'secondary';
+}
+
+const sizeTrack: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'w-8 h-4',
+  md: 'w-10 h-6',
+  lg: 'w-14 h-8',
+};
+const sizeThumb: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'w-3 h-3',
+  md: 'w-4 h-4',
+  lg: 'w-6 h-6',
+};
+const colorTrack: Record<'primary' | 'secondary', string> = {
+  primary: 'bg-blue-600',
+  secondary: 'bg-green-600',
+};
+
+interface BaseProps extends ToggleSwitchProps { }
+
+const BaseToggle = React.forwardRef<HTMLButtonElement, BaseProps>(function BaseToggle(
+  {
+    name,
+    checked,
+    defaultChecked,
+    onChange,
+    className,
+    size = 'md',
+    color = 'primary',
+    ...rest
+  },
+  ref,
+) {
+  const [internal, setInternal] = useState(defaultChecked ?? false);
+  const isControlled = typeof checked === 'boolean';
+  const value = isControlled ? checked : internal;
+  const handleChange = (next: boolean) => {
+    if (!isControlled) setInternal(next);
+    onChange?.(next);
+  };
+  const handleKey = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowLeft') {
+      handleChange(false);
+    } else if (e.key === 'ArrowRight') {
+      handleChange(true);
+    } else if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      handleChange(!value);
+    }
+  };
+  return (
+    <button
+      type="button"
+      ref={ref}
+      role="switch"
+      aria-checked={value}
+      onClick={() => handleChange(!value)}
+      onKeyDown={handleKey}
+      className={clsx('relative inline-flex items-center rounded-full transition-colors', sizeTrack[size],
+        value ? colorTrack[color] : 'bg-gray-300', className)}
+      {...rest}
+    >
+      <motion.span
+        className={clsx('absolute left-0 top-0 flex items-center justify-center rounded-full bg-white shadow', sizeThumb[size])}
+        animate={{ x: value ? '100%' : '0%' }}
+        transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+        style={{ translateX: value ? '-100%' : '0%' }}
+      />
+      <input type="checkbox" name={name} checked={value} hidden readOnly />
+    </button>
+  );
+});
+
+export const ToggleSwitch = React.forwardRef<HTMLButtonElement, ToggleSwitchProps>(function ToggleSwitch(
+  props,
+  ref,
+) {
+  const { control, rules, name, ...rest } = props;
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <BaseToggle
+            {...rest}
+            {...field}
+            checked={field.value}
+            onChange={field.onChange}
+            ref={ref}
+            name={name}
+          />
+        )}
+      />
+    );
+  }
+  return <BaseToggle ref={ref} name={name} {...rest} />;
+});
+
+export default ToggleSwitch;

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,2 @@
+export * from './ToggleSwitch';
+export * from './Slider';

--- a/my-app/src/library/stories/Slider.stories.tsx
+++ b/my-app/src/library/stories/Slider.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Slider } from '../components/inputs/Slider';
+
+const meta: Meta<typeof Slider> = {
+  title: 'library/Inputs/Slider',
+  component: Slider,
+  args: { name: 'slider', min: 0, max: 100, step: 1 },
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    color: { control: { type: 'select' }, options: ['primary', 'secondary'] },
+    min: { control: 'number' },
+    max: { control: 'number' },
+    step: { control: 'number' },
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof Slider> = {};
+export const Step10: StoryObj<typeof Slider> = { args: { step: 10 } };
+export const Range0to50: StoryObj<typeof Slider> = { args: { min: 0, max: 50 } };

--- a/my-app/src/library/stories/ToggleSwitch.stories.tsx
+++ b/my-app/src/library/stories/ToggleSwitch.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ToggleSwitch } from '../components/inputs/ToggleSwitch';
+
+const meta: Meta<typeof ToggleSwitch> = {
+  title: 'library/Inputs/ToggleSwitch',
+  component: ToggleSwitch,
+  args: { name: 'toggle' },
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    color: { control: { type: 'select' }, options: ['primary', 'secondary'] },
+  },
+};
+export default meta;
+
+export const Light: StoryObj<typeof ToggleSwitch> = {};
+export const Dark: StoryObj<typeof ToggleSwitch> = {
+  parameters: { backgrounds: { default: 'dark' } },
+};

--- a/my-app/src/library/tests/Slider.test.tsx
+++ b/my-app/src/library/tests/Slider.test.tsx
@@ -1,0 +1,22 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Slider } from '../components/inputs/Slider';
+
+describe('Slider', () => {
+  it('changes value with keyboard', () => {
+    const { getByRole } = render(<Slider name="s" />);
+    const slider = getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuenow', '0');
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(slider).toHaveAttribute('aria-valuenow', '1');
+  });
+
+  it('changes value on drag', () => {
+    const { container, getByRole } = render(<Slider name="s" />);
+    const slider = getByRole('slider');
+    const thumb = slider.querySelector('div > div:nth-child(2)') as HTMLElement;
+    fireEvent.pointerDown(thumb, { clientX: 0 });
+    fireEvent.pointerMove(thumb, { clientX: 50 });
+    fireEvent.pointerUp(thumb, { clientX: 50 });
+    expect(slider.getAttribute('aria-valuenow')).not.toBe('0');
+  });
+});

--- a/my-app/src/library/tests/ToggleSwitch.test.tsx
+++ b/my-app/src/library/tests/ToggleSwitch.test.tsx
@@ -1,0 +1,12 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ToggleSwitch } from '../components/inputs/ToggleSwitch';
+
+describe('ToggleSwitch', () => {
+  it('toggles on click', () => {
+    const { getByRole } = render(<ToggleSwitch name="t" />);
+    const toggle = getByRole('switch');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- implement ToggleSwitch and Slider components with RHF/animation
- export new inputs
- add stories showing usage
- add unit tests for toggle and slider

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a104d4a6c83219c9f93a4b350db1d