### PR TITLE
Add date/time pickers with Jalali support

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,2 @@
 export * from './primitives';
+export * from "./inputs";

--- a/my-app/src/library/components/inputs/DatePicker.tsx
+++ b/my-app/src/library/components/inputs/DatePicker.tsx
@@ -1,0 +1,253 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Controller, Control, RegisterOptions } from 'react-hook-form';
+import { motion, AnimatePresence } from 'framer-motion';
+import clsx from 'clsx';
+import {
+  toJalali,
+  toGregorian,
+  jMonthLength,
+  toFarsiDigits,
+} from './jalaliUtils';
+
+export interface Props {
+  name: string;
+  label?: string;
+  value?: Date | string;
+  defaultValue?: Date | string;
+  onChange: (date: Date | string) => void;
+  calendar?: 'gregorian' | 'jalali';
+  locale?: string;
+  format?: string;
+  placeholder?: string;
+  clearable?: boolean;
+  rules?: RegisterOptions;
+  control?: Control<any>;
+  className?: string;
+}
+
+const weekdayNamesFa = ['ش', 'ی', 'د', 'س', 'چ', 'پ', 'ج'];
+const monthNamesFa = [
+  'فروردین',
+  'اردیبهشت',
+  'خرداد',
+  'تیر',
+  'مرداد',
+  'شهریور',
+  'مهر',
+  'آبان',
+  'آذر',
+  'دی',
+  'بهمن',
+  'اسفند',
+];
+
+function formatDate(date: Date, calendar: 'gregorian' | 'jalali', locale: string) {
+  if (calendar === 'jalali') {
+    const [jy, jm, jd] = toJalali(date);
+    const month = monthNamesFa[jm - 1];
+    const digits = `${jy}/${jm}/${jd}`;
+    return `${toFarsiDigits(digits)} ${month}`;
+  }
+  return date.toLocaleDateString(locale);
+}
+
+function buildCalendar(
+  month: number,
+  year: number,
+  calendar: 'gregorian' | 'jalali',
+): { day: number; date: Date }[] {
+  const days: { day: number; date: Date }[] = [];
+  if (calendar === 'jalali') {
+    const length = jMonthLength(year, month);
+    for (let d = 1; d <= length; d++) {
+      days.push({ day: d, date: toGregorian(year, month, d) });
+    }
+  } else {
+    const length = new Date(year, month, 0).getDate();
+    for (let d = 1; d <= length; d++) {
+      days.push({ day: d, date: new Date(year, month - 1, d) });
+    }
+  }
+  return days;
+}
+
+export const DatePicker = React.forwardRef<HTMLInputElement, Props>(function DatePicker(
+  {
+    name,
+    label,
+    value,
+    defaultValue,
+    onChange,
+    calendar = 'gregorian',
+    locale = 'en-US',
+    placeholder,
+    clearable,
+    control,
+    rules,
+    className,
+  },
+  ref,
+) {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<Date | null>(
+    value ? new Date(value) : defaultValue ? new Date(defaultValue) : null,
+  );
+
+  const today = new Date();
+  const init = selected ?? today;
+  const [viewYear, setViewYear] = useState(
+    calendar === 'jalali' ? toJalali(init)[0] : init.getFullYear(),
+  );
+  const [viewMonth, setViewMonth] = useState(
+    calendar === 'jalali' ? toJalali(init)[1] : init.getMonth() + 1,
+  );
+
+  useEffect(() => {
+    if (value) setSelected(new Date(value));
+  }, [value]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, []);
+
+  const days = buildCalendar(viewMonth, viewYear, calendar);
+  const weekdayNames = locale === 'fa-IR' ? weekdayNamesFa : ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+  const handleSelect = (d: Date) => {
+    setSelected(d);
+    onChange(d);
+    setOpen(false);
+  };
+
+  const renderInput = (props?: any) => (
+    <div className={clsx('relative inline-block', className)} ref={containerRef}>
+      {label && <label className="block mb-1">{label}</label>}
+      <input
+        ref={ref as any}
+        name={name}
+        placeholder={placeholder}
+        value={selected ? formatDate(selected, calendar, locale) : ''}
+        readOnly
+        onClick={() => setOpen((o) => !o)}
+        className="border px-2 py-1 w-full"
+        {...props}
+      />
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            className="absolute z-10 bg-white dark:bg-gray-800 border mt-1 p-2 rounded shadow"
+          >
+            <div className="flex justify-between items-center mb-2">
+              <button
+                type="button"
+                onClick={() => {
+                  if (calendar === 'jalali') {
+                    let y = viewYear;
+                    let m = viewMonth - 1;
+                    if (m < 1) {
+                      m = 12;
+                      y -= 1;
+                    }
+                    setViewYear(y);
+                    setViewMonth(m);
+                  } else {
+                    const date = new Date(viewYear, viewMonth - 2, 1);
+                    setViewYear(date.getFullYear());
+                    setViewMonth(date.getMonth() + 1);
+                  }
+                }}
+              >
+                {'<'}
+              </button>
+              <span>
+                {calendar === 'jalali'
+                  ? `${toFarsiDigits(String(viewYear))} ${monthNamesFa[viewMonth - 1]}`
+                  : new Date(viewYear, viewMonth - 1).toLocaleDateString(locale, {
+                      month: 'long',
+                      year: 'numeric',
+                    })}
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  if (calendar === 'jalali') {
+                    let y = viewYear;
+                    let m = viewMonth + 1;
+                    if (m > 12) {
+                      m = 1;
+                      y += 1;
+                    }
+                    setViewYear(y);
+                    setViewMonth(m);
+                  } else {
+                    const date = new Date(viewYear, viewMonth, 1);
+                    setViewYear(date.getFullYear());
+                    setViewMonth(date.getMonth() + 1);
+                  }
+                }}
+              >
+                {'>'}
+              </button>
+            </div>
+            <div className="grid grid-cols-7 gap-1" role="grid">
+              {weekdayNames.map((w) => (
+                <div key={w} className="text-xs text-center">
+                  {w}
+                </div>
+              ))}
+              {days.map(({ day, date }) => {
+                const isSelected =
+                  selected && date.toDateString() === selected.toDateString();
+                const label = calendar === 'jalali' ? toFarsiDigits(String(day)) : day;
+                return (
+                  <button
+                    key={day}
+                    role="gridcell"
+                    aria-selected={isSelected}
+                    aria-label={label.toString()}
+                    className={clsx(
+                      'text-center text-sm w-8 h-8 rounded hover:bg-gray-200 focus:bg-gray-200',
+                      isSelected && 'bg-blue-500 text-white',
+                    )}
+                    onClick={() => handleSelect(date)}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        defaultValue={selected as any}
+        render={({ field }) =>
+          renderInput({
+            value: selected ? formatDate(selected, calendar, locale) : '',
+            onClick: () => setOpen((o) => !o),
+          })
+        }
+      />
+    );
+  }
+  return renderInput();
+});

--- a/my-app/src/library/components/inputs/DateRangePicker.tsx
+++ b/my-app/src/library/components/inputs/DateRangePicker.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { Controller, Control, RegisterOptions } from 'react-hook-form';
+import clsx from 'clsx';
+import { DatePicker, Props as DatePickerProps } from './DatePicker';
+
+export interface Props {
+  name: string;
+  label?: string;
+  value?: { start: Date | string | null; end: Date | string | null };
+  defaultValue?: { start: Date | string | null; end: Date | string | null };
+  onChange: (range: { start: Date | string | null; end: Date | string | null }) => void;
+  calendar?: 'gregorian' | 'jalali';
+  locale?: string;
+  format?: string;
+  placeholder?: string;
+  clearable?: boolean;
+  rules?: RegisterOptions;
+  control?: Control<any>;
+  className?: string;
+}
+
+export const DateRangePicker = React.forwardRef<HTMLDivElement, Props>(function DateRangePicker(
+  {
+    name,
+    label,
+    value,
+    defaultValue,
+    onChange,
+    calendar = 'gregorian',
+    locale = 'en-US',
+    control,
+    rules,
+    className,
+  },
+  ref,
+) {
+  const [internal, setInternal] = useState(
+    value ?? defaultValue ?? { start: null, end: null },
+  );
+
+  const handleStart = (date: Date | string) => {
+    const range = { ...internal, start: date };
+    setInternal(range);
+    onChange(range);
+  };
+  const handleEnd = (date: Date | string) => {
+    const range = { ...internal, end: date };
+    setInternal(range);
+    onChange(range);
+  };
+
+  const content = (
+    <div className={clsx('flex gap-2', className)} ref={ref}>
+      <DatePicker
+        name={`${name}-start`}
+        label={label ? `${label} - start` : undefined}
+        value={internal.start ?? undefined}
+        onChange={handleStart}
+        calendar={calendar}
+        locale={locale}
+      />
+      <DatePicker
+        name={`${name}-end`}
+        label={label ? `${label} - end` : undefined}
+        value={internal.end ?? undefined}
+        onChange={handleEnd}
+        calendar={calendar}
+        locale={locale}
+      />
+    </div>
+  );
+
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        defaultValue={internal as any}
+        render={() => content}
+      />
+    );
+  }
+
+  return content;
+});

--- a/my-app/src/library/components/inputs/TimePicker.tsx
+++ b/my-app/src/library/components/inputs/TimePicker.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Controller, Control, RegisterOptions } from 'react-hook-form';
+import clsx from 'clsx';
+
+export interface Props {
+  name: string;
+  label?: string;
+  value?: string;
+  defaultValue?: string;
+  onChange: (time: string) => void;
+  calendar?: 'gregorian' | 'jalali';
+  locale?: string;
+  format?: string;
+  placeholder?: string;
+  clearable?: boolean;
+  rules?: RegisterOptions;
+  control?: Control<any>;
+  className?: string;
+}
+
+export const TimePicker = React.forwardRef<HTMLInputElement, Props>(function TimePicker(
+  {
+    name,
+    label,
+    value,
+    defaultValue,
+    onChange,
+    placeholder,
+    control,
+    rules,
+    className,
+  },
+  ref,
+) {
+  const renderInput = (props?: any) => (
+    <div className={clsx('inline-block', className)}>
+      {label && <label className="block mb-1">{label}</label>}
+      <input
+        type="time"
+        name={name}
+        ref={ref as any}
+        value={value}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className="border px-2 py-1 w-full"
+        {...props}
+      />
+    </div>
+  );
+
+  if (control) {
+    return (
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) =>
+          renderInput({
+            value: field.value,
+            onChange: (e: React.ChangeEvent<HTMLInputElement>) => field.onChange(e.target.value),
+          })
+        }
+      />
+    );
+  }
+
+  return renderInput();
+});

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,3 @@
+export * from './DatePicker';
+export * from './TimePicker';
+export * from './DateRangePicker';

--- a/my-app/src/library/components/inputs/jalaliUtils.ts
+++ b/my-app/src/library/components/inputs/jalaliUtils.ts
@@ -1,0 +1,134 @@
+const breaks = [-61, 9, 38, 199, 426, 686, 756, 818, 1111, 1181, 1210, 1635, 2060, 2097, 2192, 2262, 2324, 2394, 2456, 3178];
+
+function div(a: number, b: number) {
+  return Math.floor(a / b);
+}
+function mod(a: number, b: number) {
+  return a - div(a, b) * b;
+}
+
+export interface JalCalResult {
+  leap: number;
+  gy: number;
+  march: number;
+}
+
+export function jalCal(jy: number): JalCalResult {
+  let leapJ = -14;
+  let jp = breaks[0];
+  let jm = 0;
+  let jump = 0;
+  if (jy < jp || jy >= breaks[breaks.length - 1])
+    throw new Error('Invalid Jalali year ' + jy);
+  for (let i = 1; i < breaks.length; i++) {
+    jm = breaks[i];
+    jump = jm - jp;
+    if (jy < jm) break;
+    leapJ = leapJ + div(jump, 33) * 8 + div(mod(jump, 33), 4);
+    jp = jm;
+  }
+  let n = jy - jp;
+  leapJ = leapJ + div(n, 33) * 8 + div(mod(n, 33) + 3, 4);
+  if (mod(jump, 33) === 4 && jump - n === 4) leapJ += 1;
+  const gy = jy + 621;
+  const leapG = div(gy, 4) - div((div(gy, 100) + 1) * 3, 4) - 150;
+  const march = 20 + leapJ - leapG;
+  if (jump - n < 6) n = n - jump + div(jump + 4, 33) * 33;
+  const leap = mod(mod(n + 1, 33) - 1, 4);
+  return { leap, gy, march };
+}
+
+const gDaysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+const jDaysInMonth = [31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29];
+
+function g2d(gy: number, gm: number, gd: number) {
+  let d = div((gy + div(gm - 8, 6) + 100100) * 1461, 4);
+  d += div(153 * mod(gm + 9, 12) + 2, 5) + gd - 34840408;
+  d -= div(div(gy + 100100 + div(gm - 8, 6), 100) * 3, 4);
+  return d;
+}
+
+function d2g(jdn: number) {
+  let j = 4 * jdn + 139361631;
+  j = j + div(div(4 * jdn + 183187720, 146097) * 3, 4) * 4 - 3908;
+  const i = div(mod(j, 1461), 4) * 5 + 308;
+  const gd = div(mod(i, 153), 5) + 1;
+  const gm = mod(div(i, 153), 12) + 1;
+  const gy = div(j, 1461) - 100100 + div(8 - gm, 6);
+  return [gy, gm, gd] as const;
+}
+
+function j2d(jy: number, jm: number, jd: number) {
+  const r = jalCal(jy);
+  return g2d(r.gy, 3, r.march) + (jm - 1) * 31 - div(jm, 7) * (jm - 7) + jd - 1;
+}
+
+function d2j(jdn: number) {
+  const g = d2g(jdn);
+  let jy = g[0] - 621;
+  const r = jalCal(jy);
+  const jdn1f = g2d(g[0], 3, r.march);
+  let k = jdn - jdn1f;
+  let jm;
+  let jd;
+  if (k >= 0) {
+    if (k <= 185) {
+      jm = 1 + div(k, 31);
+      jd = mod(k, 31) + 1;
+      return [jy, jm, jd] as const;
+    } else {
+      k -= 186;
+      jm = 7 + div(k, 30);
+      jd = mod(k, 30) + 1;
+      jy += 1;
+      return [jy, jm, jd] as const;
+    }
+  } else {
+    jy -= 1;
+    k += 179;
+    if (r.leap === 1) k += 1;
+    jm = 7 + div(k, 30);
+    jd = mod(k, 30) + 1;
+    return [jy, jm, jd] as const;
+  }
+}
+
+export function toJalali(date: Date) {
+  return d2j(g2d(date.getFullYear(), date.getMonth() + 1, date.getDate()));
+}
+
+export function toGregorian(jy: number, jm: number, jd: number) {
+  const g = d2g(j2d(jy, jm, jd));
+  return new Date(g[0], g[1] - 1, g[2]);
+}
+
+export function jMonthLength(jy: number, jm: number) {
+  if (jm <= 6) return 31;
+  if (jm <= 11) return 30;
+  return isLeapJalaaliYear(jy) ? 30 : 29;
+}
+
+export function isLeapJalaaliYear(jy: number) {
+  return jalCal(jy).leap === 0;
+}
+
+export function toEnglishDigits(str: string) {
+  const map: Record<string, string> = {
+    '۰': '0',
+    '۱': '1',
+    '۲': '2',
+    '۳': '3',
+    '۴': '4',
+    '۵': '5',
+    '۶': '6',
+    '۷': '7',
+    '۸': '8',
+    '۹': '9',
+  };
+  return str.replace(/[۰-۹]/g, (d) => map[d] ?? d);
+}
+
+export function toFarsiDigits(str: string) {
+  const map = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
+  return str.replace(/\d/g, (d) => map[parseInt(d, 10)]);
+}

--- a/my-app/src/library/stories/DatePicker.stories.tsx
+++ b/my-app/src/library/stories/DatePicker.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DatePicker, Props } from '../components/inputs/DatePicker';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/DatePicker',
+  component: DatePicker,
+  argTypes: {
+    calendar: { control: 'radio', options: ['gregorian', 'jalali'] },
+    locale: { control: 'text' },
+  },
+  args: { name: 'date', onChange: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<Props>;
+
+export const Gregorian: Story = {
+  args: { calendar: 'gregorian', locale: 'en-US' },
+};
+
+export const Jalali: Story = {
+  args: { calendar: 'jalali', locale: 'fa-IR' },
+};

--- a/my-app/src/library/stories/DateRangePicker.stories.tsx
+++ b/my-app/src/library/stories/DateRangePicker.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DateRangePicker, Props } from '../components/inputs/DateRangePicker';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/DateRangePicker',
+  component: DateRangePicker,
+  argTypes: {
+    calendar: { control: 'radio', options: ['gregorian', 'jalali'] },
+    locale: { control: 'text' },
+  },
+  args: { name: 'range', onChange: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<Props>;
+
+export const Default: Story = {};

--- a/my-app/src/library/stories/TimePicker.stories.tsx
+++ b/my-app/src/library/stories/TimePicker.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TimePicker, Props } from '../components/inputs/TimePicker';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/TimePicker',
+  component: TimePicker,
+  argTypes: {
+    locale: { control: 'text' },
+  },
+  args: { name: 'time', onChange: () => {} },
+};
+export default meta;
+
+type Story = StoryObj<Props>;
+
+export const Default: Story = {};

--- a/my-app/src/library/tests/DatePicker.test.tsx
+++ b/my-app/src/library/tests/DatePicker.test.tsx
@@ -1,0 +1,23 @@
+import { render, fireEvent } from '@testing-library/react';
+import { DatePicker } from '../components/inputs/DatePicker';
+
+describe('DatePicker', () => {
+  it('renders gregorian calendar', () => {
+    const { getByRole } = render(
+      <DatePicker name="d" onChange={() => {}} calendar="gregorian" />,
+    );
+    const input = getByRole('textbox') as HTMLInputElement;
+    fireEvent.click(input);
+    const grid = getByRole('grid');
+    expect(grid).toBeInTheDocument();
+  });
+
+  it('renders jalali digits', () => {
+    const { getByRole, getAllByRole } = render(
+      <DatePicker name="d" onChange={() => {}} calendar="jalali" locale="fa-IR" />,
+    );
+    fireEvent.click(getByRole('textbox'));
+    const cells = getAllByRole('gridcell');
+    expect(cells[0].textContent).toMatch(/[۰-۹]/);
+  });
+});

--- a/my-app/src/library/tests/DateRangePicker.test.tsx
+++ b/my-app/src/library/tests/DateRangePicker.test.tsx
@@ -1,0 +1,17 @@
+import { render, fireEvent } from '@testing-library/react';
+import { DateRangePicker } from '../components/inputs/DateRangePicker';
+
+describe('DateRangePicker', () => {
+  it('selects start and end dates', () => {
+    const handle = jest.fn();
+    const { getAllByRole, getByText } = render(
+      <DateRangePicker name="r" onChange={handle} />,
+    );
+    const inputs = getAllByRole('textbox');
+    fireEvent.click(inputs[0]);
+    fireEvent.click(getAllByRole('gridcell')[0]);
+    fireEvent.click(inputs[1]);
+    fireEvent.click(getAllByRole('gridcell')[10]);
+    expect(handle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/my-app/src/library/tests/TimePicker.test.tsx
+++ b/my-app/src/library/tests/TimePicker.test.tsx
@@ -1,0 +1,14 @@
+import { render, fireEvent } from '@testing-library/react';
+import { TimePicker } from '../components/inputs/TimePicker';
+
+describe('TimePicker', () => {
+  it('calls onChange with selected time', () => {
+    const handle = jest.fn();
+    const { getByLabelText } = render(
+      <TimePicker name="t" label="time" onChange={handle} />,
+    );
+    const input = getByLabelText('time') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '12:30' } });
+    expect(handle).toHaveBeenCalledWith('12:30');
+  });
+});


### PR DESCRIPTION
## Summary
- add locale-aware `DatePicker`, `TimePicker` and `DateRangePicker`
- include Jalali conversion utilities
- expose input components from barrel file
- provide tests and stories for the new inputs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1376e1888321883a8fb6fdde6eea