### PR TITLE
Add Autocomplete, MaskedInput and Rating components

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,2 @@
 export * from './primitives';
+export * from './inputs';

--- a/my-app/src/library/components/inputs/Autocomplete.tsx
+++ b/my-app/src/library/components/inputs/Autocomplete.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import clsx from 'clsx';
+import { useDebounce } from './useDebounce';
+
+export interface AutocompleteProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  optionsFetcher: string | ((q: string) => Promise<string[]>);
+  debounce?: number;
+  minChars?: number;
+  value?: string;
+  onChange?: (value: string) => void;
+  className?: string;
+}
+
+export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps>(
+  function Autocomplete(
+    {
+      optionsFetcher,
+      debounce = 300,
+      minChars = 1,
+      value,
+      onChange,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+    const [query, setQuery] = useState(value ?? '');
+    const [suggestions, setSuggestions] = useState<string[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [open, setOpen] = useState(false);
+    const [active, setActive] = useState(-1);
+    const cache = useRef<Record<string, string[]>>({});
+
+    const debouncedQuery = useDebounce(query, debounce);
+
+    useEffect(() => setQuery(value ?? ''), [value]);
+
+    useEffect(() => {
+      const fetchOptions = async (q: string) => {
+        if (cache.current[q]) {
+          setSuggestions(cache.current[q]);
+          return;
+        }
+        setLoading(true);
+        try {
+          let opts: string[] = [];
+          if (typeof optionsFetcher === 'string') {
+            const res = await fetch(`${optionsFetcher}?q=${encodeURIComponent(q)}`);
+            opts = await res.json();
+          } else {
+            opts = await optionsFetcher(q);
+          }
+          cache.current[q] = opts;
+          setSuggestions(opts);
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      if (debouncedQuery.length >= minChars) {
+        fetchOptions(debouncedQuery);
+        setOpen(true);
+      } else {
+        setOpen(false);
+        setSuggestions([]);
+      }
+    }, [debouncedQuery, minChars, optionsFetcher]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setQuery(e.target.value);
+      onChange?.(e.target.value);
+    };
+
+    const selectOption = (option: string) => {
+      setQuery(option);
+      onChange?.(option);
+      setOpen(false);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!open) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive((a) => (a + 1) % suggestions.length);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive((a) => (a - 1 + suggestions.length) % suggestions.length);
+      } else if (e.key === 'Enter') {
+        if (active >= 0 && suggestions[active]) {
+          e.preventDefault();
+          selectOption(suggestions[active]);
+        }
+      }
+    };
+
+    return (
+      <div className={clsx('relative', className)}>
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onFocus={() => query.length >= minChars && setOpen(true)}
+          role="combobox"
+          aria-expanded={open}
+          aria-activedescendant={active >= 0 ? `ac-item-${active}` : undefined}
+          className="w-full border rounded p-2"
+          {...rest}
+        />
+        {loading && (
+          <div className="absolute right-2 top-1/2 -translate-y-1/2 animate-spin" data-testid="loading">
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <circle cx="12" cy="12" r="10" strokeWidth="4" className="opacity-25" />
+              <path d="M4 12a8 8 0 018-8" strokeWidth="4" className="opacity-75" />
+            </svg>
+          </div>
+        )}
+        <AnimatePresence>
+          {open && suggestions.length > 0 && (
+            <motion.ul
+              initial={{ opacity: 0, y: -5 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -5 }}
+              className="absolute z-10 mt-1 w-full rounded border bg-white shadow"
+            >
+              {suggestions.map((opt, idx) => (
+                <li
+                  id={`ac-item-${idx}`}
+                  key={opt}
+                  role="option"
+                  aria-selected={idx === active}
+                  className={clsx('cursor-pointer p-2', idx === active && 'bg-gray-200')}
+                  onMouseDown={() => selectOption(opt)}
+                  onMouseEnter={() => setActive(idx)}
+                >
+                  {opt}
+                </li>
+              ))}
+            </motion.ul>
+          )}
+        </AnimatePresence>
+      </div>
+    );
+  },
+);

--- a/my-app/src/library/components/inputs/MaskedInput.tsx
+++ b/my-app/src/library/components/inputs/MaskedInput.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+export interface MaskedInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  maskPattern: string;
+  maskChar?: string;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (val: string) => void;
+  className?: string;
+}
+
+function applyMask(pattern: string, maskChar: string, value: string) {
+  const digits = value.replace(/[^\w]/g, '');
+  let result = '';
+  let di = 0;
+  for (const ch of pattern) {
+    if (ch === '#') {
+      result += digits[di] ?? maskChar;
+      di += 1;
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
+  function MaskedInput(
+    {
+      maskPattern,
+      maskChar = '_',
+      value,
+      defaultValue = '',
+      onChange,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+    const isControlled = value !== undefined;
+    const [internal, setInternal] = useState(defaultValue);
+    const val = isControlled ? value! : internal;
+
+    const masked = applyMask(maskPattern, maskChar, val);
+
+    useEffect(() => {
+      if (!isControlled) setInternal(defaultValue);
+    }, [defaultValue, isControlled]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value.replace(/[^\w]/g, '');
+      if (!isControlled) setInternal(raw);
+      onChange?.(raw);
+    };
+
+    const clear = () => {
+      if (!isControlled) setInternal('');
+      onChange?.('');
+    };
+
+    return (
+      <div className={clsx('relative inline-flex items-center', className)}>
+        <input
+          ref={inputRef}
+          value={masked}
+          onChange={handleChange}
+          aria-label={rest['aria-label']}
+          aria-invalid={rest['aria-invalid']}
+          className="border rounded p-2 pr-6"
+          {...rest}
+        />
+        {val && (
+          <button
+            type="button"
+            onClick={clear}
+            className="absolute right-1 text-gray-500"
+            tabIndex={-1}
+            aria-label="Clear"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    );
+  },
+);

--- a/my-app/src/library/components/inputs/Rating.tsx
+++ b/my-app/src/library/components/inputs/Rating.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+
+export interface RatingProps extends React.HTMLAttributes<HTMLDivElement> {
+  max?: number;
+  value?: number;
+  defaultValue?: number;
+  onChange?: (val: number) => void;
+  readOnly?: boolean;
+  size?: number;
+  className?: string;
+}
+
+const Star = ({ filled, size }: { filled: boolean; size: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill={filled ? 'currentColor' : 'none'}
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+  </svg>
+);
+
+export const Rating = React.forwardRef<HTMLDivElement, RatingProps>(
+  function Rating(
+    {
+      max = 5,
+      value,
+      defaultValue = 0,
+      onChange,
+      readOnly = false,
+      size = 24,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const isControlled = value !== undefined;
+    const [internal, setInternal] = useState(defaultValue);
+    const [hover, setHover] = useState(0);
+
+    const rating = isControlled ? value! : internal;
+
+    const handleSelect = (i: number) => {
+      if (readOnly) return;
+      if (!isControlled) setInternal(i);
+      onChange?.(i);
+    };
+
+    return (
+      <div
+        ref={ref}
+        role="radiogroup"
+        className={clsx('inline-flex', className)}
+        {...rest}
+      >
+        {Array.from({ length: max }).map((_, idx) => {
+          const index = idx + 1;
+          const filled = hover ? index <= hover : index <= rating;
+          return (
+            <motion.button
+              type="button"
+              key={index}
+              role="radio"
+              aria-checked={index === rating}
+              className="p-1"
+              onMouseEnter={() => !readOnly && setHover(index)}
+              onMouseLeave={() => !readOnly && setHover(0)}
+              onClick={() => handleSelect(index)}
+              whileHover={!readOnly ? { scale: 1.2 } : undefined}
+              whileTap={!readOnly ? { scale: 0.9 } : undefined}
+            >
+              <Star filled={filled} size={size} />
+            </motion.button>
+          );
+        })}
+      </div>
+    );
+  },
+);

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,4 @@
+export * from './Autocomplete';
+export * from './MaskedInput';
+export * from './Rating';
+export * from './useDebounce';

--- a/my-app/src/library/components/inputs/useDebounce.ts
+++ b/my-app/src/library/components/inputs/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/my-app/src/library/stories/Autocomplete.stories.tsx
+++ b/my-app/src/library/stories/Autocomplete.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Autocomplete, AutocompleteProps } from '../components/inputs/Autocomplete';
+
+const meta: Meta<AutocompleteProps> = {
+  title: 'library/Inputs/Autocomplete',
+  component: Autocomplete,
+  argTypes: {
+    optionsFetcher: { control: false },
+    debounce: { control: 'number' },
+    minChars: { control: 'number' },
+    value: { control: 'text' },
+    className: { control: 'text' },
+  },
+  args: {
+    optionsFetcher: async (q: string) => ['apple', 'banana', 'orange'].filter((o) => o.includes(q)),
+    debounce: 300,
+    minChars: 1,
+    value: '',
+  },
+};
+export default meta;
+
+export const Default: StoryObj<AutocompleteProps> = {};

--- a/my-app/src/library/stories/MaskedInput.stories.tsx
+++ b/my-app/src/library/stories/MaskedInput.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MaskedInput, MaskedInputProps } from '../components/inputs/MaskedInput';
+
+const meta: Meta<MaskedInputProps> = {
+  title: 'library/Inputs/MaskedInput',
+  component: MaskedInput,
+  argTypes: {
+    maskPattern: { control: 'text' },
+    maskChar: { control: 'text' },
+    value: { control: 'text' },
+    defaultValue: { control: 'text' },
+    className: { control: 'text' },
+  },
+  args: {
+    maskPattern: '###-###',
+    maskChar: '_',
+    defaultValue: '',
+  },
+};
+export default meta;
+
+export const Default: StoryObj<MaskedInputProps> = {};

--- a/my-app/src/library/stories/Rating.stories.tsx
+++ b/my-app/src/library/stories/Rating.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Rating, RatingProps } from '../components/inputs/Rating';
+
+const meta: Meta<RatingProps> = {
+  title: 'library/Inputs/Rating',
+  component: Rating,
+  argTypes: {
+    max: { control: 'number' },
+    value: { control: 'number' },
+    defaultValue: { control: 'number' },
+    readOnly: { control: 'boolean' },
+    size: { control: 'number' },
+    className: { control: 'text' },
+  },
+  args: {
+    max: 5,
+    defaultValue: 3,
+    readOnly: false,
+    size: 24,
+  },
+};
+export default meta;
+
+export const Default: StoryObj<RatingProps> = {};

--- a/my-app/src/library/tests/Autocomplete.test.tsx
+++ b/my-app/src/library/tests/Autocomplete.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { Autocomplete } from '../components/inputs/Autocomplete';
+
+describe('Autocomplete', () => {
+  it('fetches suggestions as user types', async () => {
+    const fetcher = jest.fn(async () => ['one']);
+    const { getByRole } = render(
+      <Autocomplete optionsFetcher={fetcher} debounce={0} />,
+    );
+    fireEvent.change(getByRole('combobox'), { target: { value: 'o' } });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledWith('o'));
+  });
+
+  it('allows keyboard navigation and selection', async () => {
+    const fetcher = jest.fn(async () => ['a', 'b']);
+    const { getByRole, getByText } = render(
+      <Autocomplete optionsFetcher={fetcher} debounce={0} minChars={0} />,
+    );
+    const input = getByRole('combobox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    await waitFor(() => getByText('a'));
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(input.value).toBe('b');
+  });
+
+  it('selects option on click', async () => {
+    const fetcher = jest.fn(async () => ['foo', 'bar']);
+    const { getByRole, getByText } = render(
+      <Autocomplete optionsFetcher={fetcher} debounce={0} minChars={0} />,
+    );
+    const input = getByRole('combobox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    const option = await waitFor(() => getByText('bar'));
+    fireEvent.mouseDown(option);
+    expect(input.value).toBe('bar');
+  });
+});

--- a/my-app/src/library/tests/MaskedInput.test.tsx
+++ b/my-app/src/library/tests/MaskedInput.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render } from '@testing-library/react';
+import { MaskedInput } from '../components/inputs/MaskedInput';
+
+describe('MaskedInput', () => {
+  it('applies mask pattern', () => {
+    const { getByLabelText } = render(
+      <MaskedInput maskPattern="###-###" aria-label="m" />,
+    );
+    const input = getByLabelText('m') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '12345' } });
+    expect(input.value).toBe('123-45_');
+  });
+
+  it('handles paste input', () => {
+    const { getByLabelText } = render(
+      <MaskedInput maskPattern="###-###" aria-label="m" />,
+    );
+    const input = getByLabelText('m') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '123456' } });
+    expect(input.value).toBe('123-456');
+  });
+});

--- a/my-app/src/library/tests/Rating.test.tsx
+++ b/my-app/src/library/tests/Rating.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render } from '@testing-library/react';
+import { Rating } from '../components/inputs/Rating';
+
+describe('Rating', () => {
+  it('changes highlight on hover', () => {
+    const { getAllByRole } = render(<Rating />);
+    const stars = getAllByRole('radio');
+    fireEvent.mouseEnter(stars[2]);
+    expect(stars[2].querySelector('svg')?.getAttribute('fill')).toBe('currentColor');
+  });
+
+  it('selects on click', () => {
+    const handle = jest.fn();
+    const { getAllByRole } = render(<Rating onChange={handle} />);
+    const stars = getAllByRole('radio');
+    fireEvent.click(stars[3]);
+    expect(handle).toHaveBeenCalledWith(4);
+  });
+
+  it('does not change when readOnly', () => {
+    const handle = jest.fn();
+    const { getAllByRole } = render(<Rating readOnly onChange={handle} />);
+    const stars = getAllByRole('radio');
+    fireEvent.click(stars[4]);
+    expect(handle).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- implement Autocomplete, MaskedInput and Rating components
- add utility hook `useDebounce`
- export new components in library
- provide Storybook stories and Jest tests

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a13b69ea083219a1bf9cc470c0506