### PR TITLE
Add input components with tests

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,2 @@
 export * from './primitives';
+export * from './inputs';

--- a/my-app/src/library/components/inputs/Autocomplete.tsx
+++ b/my-app/src/library/components/inputs/Autocomplete.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import clsx from 'clsx';
+import { AnimatePresence, motion } from 'framer-motion';
+
+function useDebounce<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = React.useState(value);
+  React.useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+  return debounced;
+}
+
+export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  optionsFetcher: string | ((query: string) => Promise<string[]>);
+  debounce?: number;
+  minChars?: number;
+  value?: string;
+  onChange?: (value: string) => void;
+  className?: string;
+}
+
+export const Autocomplete = React.forwardRef<HTMLInputElement, Props>(function Autocomplete(
+  {
+    optionsFetcher,
+    debounce = 300,
+    minChars = 2,
+    value: valueProp,
+    onChange,
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const [query, setQuery] = React.useState(valueProp ?? '');
+  const [suggestions, setSuggestions] = React.useState<string[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+  const [activeIndex, setActiveIndex] = React.useState(-1);
+  const cache = React.useRef<Record<string, string[]>>({});
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+  React.useEffect(() => {
+    setQuery(valueProp ?? '');
+  }, [valueProp]);
+
+  const debouncedQuery = useDebounce(query, debounce);
+
+  React.useEffect(() => {
+    if (debouncedQuery.length < minChars) {
+      setSuggestions([]);
+      return;
+    }
+    if (cache.current[debouncedQuery]) {
+      setSuggestions(cache.current[debouncedQuery]);
+      return;
+    }
+    let ignore = false;
+    setLoading(true);
+    const fetcher =
+      typeof optionsFetcher === 'string'
+        ? (q: string) =>
+            fetch(`${optionsFetcher}?q=${encodeURIComponent(q)}`).then(res => res.json())
+        : optionsFetcher;
+    fetcher(debouncedQuery)
+      .then(res => {
+        if (ignore) return;
+        cache.current[debouncedQuery] = res;
+        setSuggestions(res);
+      })
+      .finally(() => !ignore && setLoading(false));
+    return () => {
+      ignore = true;
+    };
+  }, [debouncedQuery, optionsFetcher, minChars]);
+
+  const select = (val: string) => {
+    onChange?.(val);
+    if (valueProp === undefined) setQuery(val);
+    setOpen(false);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    if (valueProp === undefined) setQuery(val);
+    onChange?.(val);
+    setOpen(true);
+    setActiveIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      setOpen(true);
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex(i => (i + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(i => (i - 1 + suggestions.length) % suggestions.length);
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      select(suggestions[activeIndex]);
+    }
+  };
+
+  const value = valueProp !== undefined ? valueProp : query;
+
+  return (
+    <div className="relative">
+      <input
+        ref={inputRef}
+        className={clsx('w-full', className)}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => setOpen(true)}
+        role="combobox"
+        aria-expanded={open}
+        aria-activedescendant={activeIndex >= 0 ? `option-${activeIndex}` : undefined}
+        {...rest}
+      />
+      {loading && (
+        <span className="absolute right-2 top-1/2 -translate-y-1/2 animate-spin border-2 border-gray-300 border-t-gray-600 rounded-full w-4 h-4" />
+      )}
+      <AnimatePresence>
+        {open && suggestions.length > 0 && (
+          <motion.ul
+            className="absolute z-10 mt-1 w-full bg-white border rounded shadow"
+            initial={{ opacity: 0, y: -5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -5 }}
+          >
+            {suggestions.map((s, i) => (
+              <li
+                key={s}
+                id={`option-${i}`}
+                className={clsx(
+                  'p-2 cursor-pointer hover:bg-gray-200',
+                  activeIndex === i && 'bg-gray-200',
+                )}
+                onMouseDown={e => e.preventDefault()}
+                onClick={() => select(s)}
+                role="option"
+                aria-selected={activeIndex === i}
+              >
+                {s}
+              </li>
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+});

--- a/my-app/src/library/components/inputs/MaskedInput.tsx
+++ b/my-app/src/library/components/inputs/MaskedInput.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import clsx from 'clsx';
+
+function applyMask(value: string, pattern: string, maskChar: string) {
+  const digits = value.replace(/\D/g, '');
+  let result = '';
+  let di = 0;
+  for (let i = 0; i < pattern.length; i++) {
+    const p = pattern[i];
+    if (p === '#') {
+      result += digits[di] ?? maskChar;
+      di += 1;
+    } else {
+      result += p;
+    }
+  }
+  return result;
+}
+
+function unmask(masked: string) {
+  return masked.replace(/\D/g, '');
+}
+
+export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  maskPattern: string;
+  maskChar?: string;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  className?: string;
+}
+
+export const MaskedInput = React.forwardRef<HTMLInputElement, Props>(function MaskedInput(
+  { maskPattern, maskChar = '_', value: valueProp, defaultValue, onChange, className, ...rest },
+  ref,
+) {
+  const [raw, setRaw] = React.useState(() => unmask(valueProp ?? defaultValue ?? ''));
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+  React.useEffect(() => {
+    if (valueProp !== undefined) {
+      setRaw(unmask(valueProp));
+    }
+  }, [valueProp]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const nextRaw = unmask(e.target.value);
+    if (valueProp === undefined) setRaw(nextRaw);
+    onChange?.(applyMask(nextRaw, maskPattern, maskChar));
+  };
+
+  const clear = () => {
+    if (valueProp === undefined) setRaw('');
+    onChange?.('');
+  };
+
+  const masked = applyMask(raw, maskPattern, maskChar);
+
+  return (
+    <div className="relative inline-block">
+      <input
+        ref={inputRef}
+        className={clsx(className, 'pr-6')}
+        value={valueProp !== undefined ? valueProp : masked}
+        onChange={handleChange}
+        aria-label={rest['aria-label']}
+        aria-invalid={rest['aria-invalid']}
+        {...rest}
+      />
+      {masked && (
+        <button
+          type="button"
+          className="absolute right-1 top-1/2 -translate-y-1/2 text-gray-500"
+          onClick={clear}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+});

--- a/my-app/src/library/components/inputs/Rating.tsx
+++ b/my-app/src/library/components/inputs/Rating.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+
+const sizes: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'w-4 h-4',
+  md: 'w-6 h-6',
+  lg: 'w-8 h-8',
+};
+
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  max?: number;
+  value?: number;
+  defaultValue?: number;
+  onChange?: (value: number) => void;
+  readOnly?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export const Rating = React.forwardRef<HTMLDivElement, Props>(function Rating(
+  {
+    max = 5,
+    value: valueProp,
+    defaultValue = 0,
+    onChange,
+    readOnly,
+    size = 'md',
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const [internal, setInternal] = React.useState(defaultValue);
+  const [hover, setHover] = React.useState(0);
+  const value = valueProp !== undefined ? valueProp : internal;
+
+  const handleSelect = (v: number) => {
+    if (readOnly) return;
+    onChange?.(v);
+    if (valueProp === undefined) setInternal(v);
+  };
+
+  const handleHover = (v: number) => {
+    if (readOnly) return;
+    setHover(v);
+  };
+
+  const display = hover || value;
+
+  return (
+    <div ref={ref} role="radiogroup" className={clsx('inline-flex', className)} {...rest}>
+      {Array.from({ length: max }).map((_, i) => {
+        const starVal = i + 1;
+        return (
+          <motion.span
+            key={starVal}
+            role="radio"
+            aria-checked={value >= starVal}
+            className="cursor-pointer"
+            whileHover={!readOnly ? { scale: 1.2 } : undefined}
+            onMouseEnter={() => handleHover(starVal)}
+            onMouseLeave={() => handleHover(0)}
+            onClick={() => handleSelect(starVal)}
+          >
+            <svg
+              className={clsx(sizes[size], display >= starVal ? 'text-yellow-400' : 'text-gray-300')}
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.974a1 1 0 00.95.69h4.178c.969 0 1.371 1.24.588 1.81l-3.384 2.46a1 1 0 00-.364 1.118l1.287 3.974c.3.921-.755 1.688-1.54 1.118l-3.384-2.46a1 1 0 00-1.175 0l-3.384 2.46c-.784.57-1.838-.197-1.539-1.118l1.287-3.974a1 1 0 00-.364-1.118L2.049 9.401c-.783-.57-.38-1.81.588-1.81h4.178a1 1 0 00.95-.69l1.286-3.974z" />
+            </svg>
+          </motion.span>
+        );
+      })}
+    </div>
+  );
+});

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,3 @@
+export * from './Autocomplete';
+export * from './MaskedInput';
+export * from './Rating';

--- a/my-app/src/library/stories/Autocomplete.stories.tsx
+++ b/my-app/src/library/stories/Autocomplete.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Autocomplete, Props } from '../components/inputs/Autocomplete';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/Autocomplete',
+  component: Autocomplete,
+  argTypes: {
+    optionsFetcher: { control: false },
+    value: { control: 'text' },
+    debounce: { control: 'number' },
+    minChars: { control: 'number' },
+    className: { control: 'text' },
+  },
+  args: {
+    optionsFetcher: (q: string) => Promise.resolve([`${q}1`, `${q}2`, `${q}3`]),
+  },
+};
+export default meta;
+
+type Story = StoryObj<Props>;
+
+export const Default: Story = {};

--- a/my-app/src/library/stories/MaskedInput.stories.tsx
+++ b/my-app/src/library/stories/MaskedInput.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MaskedInput, Props } from '../components/inputs/MaskedInput';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/MaskedInput',
+  component: MaskedInput,
+  argTypes: {
+    maskPattern: { control: 'text' },
+    maskChar: { control: 'text' },
+    value: { control: 'text' },
+    className: { control: 'text' },
+  },
+  args: {
+    maskPattern: '###-###',
+  },
+};
+export default meta;
+
+type Story = StoryObj<Props>;
+
+export const Default: Story = {};

--- a/my-app/src/library/stories/Rating.stories.tsx
+++ b/my-app/src/library/stories/Rating.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Rating, Props } from '../components/inputs/Rating';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/Rating',
+  component: Rating,
+  argTypes: {
+    max: { control: 'number' },
+    value: { control: 'number' },
+    readOnly: { control: 'boolean' },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    className: { control: 'text' },
+  },
+  args: { max: 5, size: 'md' },
+};
+export default meta;
+
+type Story = StoryObj<Props>;
+
+export const Default: Story = {};

--- a/my-app/src/library/tests/Autocomplete.test.tsx
+++ b/my-app/src/library/tests/Autocomplete.test.tsx
@@ -1,0 +1,35 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { Autocomplete } from '../components/inputs/Autocomplete';
+
+describe('Autocomplete', () => {
+  it('fetches suggestions after typing', async () => {
+    jest.useFakeTimers();
+    const fetcher = jest.fn(() => Promise.resolve(['one']));
+    const { getByRole, findByText } = render(
+      <Autocomplete optionsFetcher={fetcher} debounce={300} />,
+    );
+    const input = getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'on' } });
+    jest.advanceTimersByTime(300);
+    await findByText('one');
+    expect(fetcher).toHaveBeenCalledWith('on');
+    jest.useRealTimers();
+  });
+
+  it('allows arrow navigation and selection', async () => {
+    jest.useFakeTimers();
+    const fetcher = jest.fn(() => Promise.resolve(['a', 'b', 'c']));
+    const { getByRole, findByText } = render(
+      <Autocomplete optionsFetcher={fetcher} debounce={0} />,
+    );
+    const input = getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'a' } });
+    jest.advanceTimersByTime(0);
+    await findByText('a');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect((input as HTMLInputElement).value).toBe('b');
+    jest.useRealTimers();
+  });
+});

--- a/my-app/src/library/tests/MaskedInput.test.tsx
+++ b/my-app/src/library/tests/MaskedInput.test.tsx
@@ -1,0 +1,23 @@
+import { render, fireEvent } from '@testing-library/react';
+import { MaskedInput } from '../components/inputs/MaskedInput';
+
+describe('MaskedInput', () => {
+  it('applies mask on typing', () => {
+    const { getByLabelText } = render(
+      <MaskedInput maskPattern="###-###" aria-label="masked" />,
+    );
+    const input = getByLabelText('masked') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '123456' } });
+    expect(input.value).toBe('123-456');
+  });
+
+  it('handles paste with formatting', () => {
+    const { getByLabelText } = render(
+      <MaskedInput maskPattern="###-###" aria-label="masked" />,
+    );
+    const input = getByLabelText('masked') as HTMLInputElement;
+    fireEvent.paste(input, { clipboardData: { getData: () => '987654' } } as any);
+    fireEvent.change(input, { target: { value: '987654' } });
+    expect(input.value).toBe('987-654');
+  });
+});

--- a/my-app/src/library/tests/Rating.test.tsx
+++ b/my-app/src/library/tests/Rating.test.tsx
@@ -1,0 +1,20 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Rating } from '../components/inputs/Rating';
+
+describe('Rating', () => {
+  it('changes on hover and select', () => {
+    const { getAllByRole } = render(<Rating max={3} />);
+    const stars = getAllByRole('radio');
+    fireEvent.mouseEnter(stars[1]);
+    expect(stars[1]).toHaveClass('text-yellow-400');
+    fireEvent.click(stars[1]);
+    expect(stars[1]).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('readOnly prevents changes', () => {
+    const { getAllByRole } = render(<Rating max={2} readOnly defaultValue={1} />);
+    const stars = getAllByRole('radio');
+    fireEvent.click(stars[1]);
+    expect(stars[1]).toHaveAttribute('aria-checked', 'false');
+  });
+});


### PR DESCRIPTION
## Summary
- add Autocomplete, MaskedInput and Rating input components
- export them from component index
- add stories demonstrating controls
- include Jest tests for core behaviors

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a13d18a3c8321a14d06955d4aed48