### PR TITLE
Add RichTextEditor input component

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,2 @@
 export * from './primitives';
+export * from './inputs';

--- a/my-app/src/library/components/inputs/RichTextEditor.tsx
+++ b/my-app/src/library/components/inputs/RichTextEditor.tsx
@@ -1,0 +1,50 @@
+import React, { forwardRef, Suspense } from 'react';
+
+const ReactQuill = React.lazy(() => import('react-quill'));
+
+export interface RichTextEditorProps {
+  value?: string;
+  onChange?: (value: string) => void;
+  modules?: any;
+  formats?: string[];
+  className?: string;
+  theme?: string;
+  toolbar?: any;
+}
+
+export const RichTextEditor = forwardRef<any, RichTextEditorProps>(
+  (
+    {
+      value,
+      onChange,
+      modules,
+      formats,
+      className = '',
+      theme = 'snow',
+      toolbar,
+      ...rest
+    },
+    ref,
+  ) => {
+    const computedModules = modules ?? (toolbar ? { toolbar } : undefined);
+    return (
+      <div className={['w-full', className].filter(Boolean).join(' ')}>
+        <Suspense fallback={<div>Loading editor...</div>}>
+          <ReactQuill
+            ref={ref}
+            value={value}
+            onChange={onChange}
+            modules={computedModules}
+            formats={formats}
+            theme={theme}
+            role="textbox"
+            aria-multiline="true"
+            {...rest}
+          />
+        </Suspense>
+      </div>
+    );
+  },
+);
+
+export default RichTextEditor;

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,1 @@
+export * from './RichTextEditor';

--- a/my-app/src/library/stories/RichTextEditor.stories.tsx
+++ b/my-app/src/library/stories/RichTextEditor.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { RichTextEditor } from '../components/inputs/RichTextEditor';
+
+const meta: Meta<typeof RichTextEditor> = {
+  title: 'library/Inputs/RichTextEditor',
+  component: RichTextEditor,
+  args: {
+    value: '',
+    toolbar: [['bold', 'italic'], ['link']],
+  },
+  argTypes: {
+    value: { control: 'text' },
+    modules: { control: 'object' },
+    formats: { control: 'object' },
+    className: { control: 'text' },
+    theme: { control: 'text' },
+    toolbar: { control: 'object' },
+  },
+};
+export default meta;
+
+export const Basic: StoryObj<typeof RichTextEditor> = {};
+
+export const CustomToolbar: StoryObj<typeof RichTextEditor> = {
+  args: {
+    toolbar: [['bold'], ['italic'], [{ list: 'bullet' }]],
+  },
+};
+
+export const Controlled: StoryObj<typeof RichTextEditor> = {
+  render: (args) => {
+    const [value, setValue] = useState('');
+    return <RichTextEditor {...args} value={value} onChange={setValue} />;
+  },
+};
+
+export const Uncontrolled: StoryObj<typeof RichTextEditor> = {
+  args: {
+    value: undefined,
+  },
+};

--- a/my-app/src/library/tests/RichTextEditor.test.tsx
+++ b/my-app/src/library/tests/RichTextEditor.test.tsx
@@ -1,0 +1,54 @@
+jest.mock('react-quill', () => {
+  const React = require('react');
+  const mockQuillRender = jest.fn();
+  const Quill = React.forwardRef((props: any, ref) => {
+    mockQuillRender(props);
+    return (
+      <div>
+        <button data-testid="bold" onClick={() => props.onChange?.('bold')}>B</button>
+        <textarea
+          data-testid="quill"
+          ref={ref as any}
+          value={props.value || ''}
+          onChange={(e) => props.onChange?.((e.target as HTMLTextAreaElement).value)}
+        />
+      </div>
+    );
+  });
+  return { __esModule: true, default: Quill, mockQuillRender };
+});
+
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { RichTextEditor } from '../components/inputs/RichTextEditor';
+import { mockQuillRender } from 'react-quill';
+
+describe('RichTextEditor', () => {
+  it('lazy loads editor', async () => {
+    render(<RichTextEditor />);
+    await waitFor(() => expect(mockQuillRender).toHaveBeenCalled());
+    expect(screen.getByTestId('quill')).toBeInTheDocument();
+  });
+
+  it('handles typing', async () => {
+    const handleChange = jest.fn();
+    render(<RichTextEditor onChange={handleChange} />);
+    await waitFor(() => expect(mockQuillRender).toHaveBeenCalled());
+    fireEvent.change(screen.getByTestId('quill'), { target: { value: 'hello' } });
+    expect(handleChange).toHaveBeenCalledWith('hello');
+  });
+
+  it('passes toolbar config', async () => {
+    const toolbar = ['bold'];
+    render(<RichTextEditor toolbar={toolbar} />);
+    await waitFor(() => expect(mockQuillRender).toHaveBeenCalled());
+    expect(mockQuillRender.mock.calls[0][0].modules).toEqual({ toolbar });
+  });
+
+  it('toolbar button click fires change', async () => {
+    const handleChange = jest.fn();
+    render(<RichTextEditor onChange={handleChange} />);
+    await waitFor(() => expect(mockQuillRender).toHaveBeenCalled());
+    fireEvent.click(screen.getByTestId('bold'));
+    expect(handleChange).toHaveBeenCalledWith('bold');
+  });
+});


### PR DESCRIPTION
## Summary
- add lazy loaded `RichTextEditor` component
- expose new inputs index and export from components index
- create storybook example with controlled/uncontrolled modes
- provide basic unit tests for the editor

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686a13ebd8bc8321a8b14588d200994d