### PR TITLE
Add FileUploader component

### DIFF
--- a/my-app/src/library/components/index.ts
+++ b/my-app/src/library/components/index.ts
@@ -1,1 +1,3 @@
 export * from './primitives';
+export * from './typography';
+export * from './inputs';

--- a/my-app/src/library/components/inputs/FileUploader.tsx
+++ b/my-app/src/library/components/inputs/FileUploader.tsx
@@ -1,0 +1,178 @@
+import React, { useCallback, useState, useImperativeHandle } from 'react';
+import { useDropzone } from 'react-dropzone';
+import ReactCrop, { Crop } from 'react-image-crop';
+import { motion, AnimatePresence } from 'framer-motion';
+import clsx from 'clsx';
+import 'react-image-crop/dist/ReactCrop.css';
+
+export interface FileData {
+  file: File;
+  preview: string;
+  croppedPreview?: string;
+}
+
+export interface FileUploaderRef {
+  removeFile: (file: File) => void;
+}
+
+export interface Props {
+  name: string;
+  label?: string;
+  multiple?: boolean;
+  accept?: string | string[];
+  onUpload?: (files: File[]) => void;
+  className?: string;
+}
+
+export const FileUploader = React.forwardRef<FileUploaderRef, Props>(function FileUploader(
+  { name, label, multiple = false, accept, onUpload, className },
+  ref,
+) {
+  const [files, setFiles] = useState<FileData[]>([]);
+  const [cropFile, setCropFile] = useState<FileData | null>(null);
+  const [crop, setCrop] = useState<Crop>({ unit: '%', width: 80, x: 10, y: 10 });
+  const [completedCrop, setCompletedCrop] = useState<Crop>();
+  const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
+
+  const onDrop = useCallback(
+    (accepted: File[]) => {
+      const mapped = accepted.map((f) => ({ file: f, preview: URL.createObjectURL(f) }));
+      setFiles((prev) => [...prev, ...mapped]);
+      onUpload?.(accepted);
+    },
+    [onUpload],
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple,
+    accept,
+  });
+
+  const removeFile = useCallback((file: File) => {
+    setFiles((prev) => prev.filter((f) => f.file !== file));
+  }, []);
+
+  useImperativeHandle(ref, () => ({ removeFile }), [removeFile]);
+
+  const startCrop = useCallback((fd: FileData) => {
+    setCropFile(fd);
+    setCrop({ unit: '%', width: 80, x: 10, y: 10 });
+    setCompletedCrop(undefined);
+  }, []);
+
+  const applyCrop = useCallback(() => {
+    if (!cropFile || !completedCrop || !imageEl) return;
+    const canvas = document.createElement('canvas');
+    const scaleX = imageEl.naturalWidth / imageEl.width;
+    const scaleY = imageEl.naturalHeight / imageEl.height;
+    canvas.width = completedCrop.width || 0;
+    canvas.height = completedCrop.height || 0;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(
+      imageEl,
+      (completedCrop.x || 0) * scaleX,
+      (completedCrop.y || 0) * scaleY,
+      (completedCrop.width || 0) * scaleX,
+      (completedCrop.height || 0) * scaleY,
+      0,
+      0,
+      completedCrop.width || 0,
+      completedCrop.height || 0,
+    );
+    canvas.toBlob((blob) => {
+      if (!blob) return;
+      const newFile = new File([blob], cropFile.file.name, { type: cropFile.file.type });
+      const preview = URL.createObjectURL(blob);
+      setFiles((prev) =>
+        prev.map((f) => (f.file === cropFile.file ? { ...f, file: newFile, croppedPreview: preview } : f)),
+      );
+      setCropFile(null);
+    });
+  }, [cropFile, completedCrop, imageEl]);
+
+  const listRoleProps = { role: 'list', 'aria-label': 'Uploaded files' } as const;
+
+  return (
+    <div className={clsx('border border-dashed p-4', className)}>
+      {label && (
+        <label htmlFor={name} className="block mb-2">
+          {label}
+        </label>
+      )}
+      <div
+        {...getRootProps({
+          className: clsx('p-4 text-center cursor-pointer', isDragActive && 'bg-gray-100'),
+        })}
+      >
+        <input {...getInputProps({ name })} />
+        {isDragActive ? <p>Drop the files here...</p> : <p>Drag & drop files here, or click to select</p>}
+      </div>
+      <ul {...listRoleProps} className="flex flex-wrap gap-2 mt-2">
+        <AnimatePresence>
+          {files.map((f) => {
+            const preview = f.croppedPreview || f.preview;
+            const isImage = f.file.type.startsWith('image/');
+            const isVideo = f.file.type.startsWith('video/');
+            return (
+              <motion.li
+                key={preview}
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
+                className="relative"
+              >
+                {isImage && <img src={preview} alt={f.file.name} className="h-20 w-20 object-cover" />}
+                {isVideo && (
+                  <video src={preview} className="h-20 w-20 object-cover" aria-label={f.file.name} />
+                )}
+                {!isImage && !isVideo && <span>{f.file.name}</span>}
+                <button
+                  type="button"
+                  onClick={() => removeFile(f.file)}
+                  aria-label={`Remove ${f.file.name}`}
+                  className="absolute top-0 right-0 bg-white bg-opacity-70"
+                >
+                  ✕
+                </button>
+                {isImage && (
+                  <button
+                    type="button"
+                    onClick={() => startCrop(f)}
+                    aria-label={`Crop ${f.file.name}`}
+                    className="absolute bottom-0 right-0 bg-white bg-opacity-70"
+                  >
+                    Crop
+                  </button>
+                )}
+              </motion.li>
+            );
+          })}
+        </AnimatePresence>
+      </ul>
+      {cropFile && (
+        <div className="mt-4">
+          <ReactCrop
+            crop={crop}
+            onChange={(c) => setCrop(c)}
+            onComplete={(c) => setCompletedCrop(c)}
+            onImageLoaded={(img) => setImageEl(img)}
+          >
+            <img src={cropFile.preview} alt="Crop source" />
+          </ReactCrop>
+          <div className="mt-2 flex gap-2">
+            <button type="button" onClick={applyCrop} aria-label="Apply crop" className="px-2 py-1 border">
+              Apply
+            </button>
+            <button type="button" onClick={() => setCropFile(null)} aria-label="Cancel crop" className="px-2 py-1 border">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default FileUploader;

--- a/my-app/src/library/components/inputs/index.ts
+++ b/my-app/src/library/components/inputs/index.ts
@@ -1,0 +1,1 @@
+export * from './FileUploader';

--- a/my-app/src/library/stories/FileUploader.stories.tsx
+++ b/my-app/src/library/stories/FileUploader.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FileUploader, Props } from '../components/inputs/FileUploader';
+
+const meta: Meta<Props> = {
+  title: 'library/Inputs/FileUploader',
+  component: FileUploader,
+  argTypes: {
+    name: { control: 'text' },
+    label: { control: 'text' },
+    multiple: { control: 'boolean' },
+    accept: { control: 'text' },
+    className: { control: 'text' },
+  },
+  args: { name: 'files', label: 'Upload', multiple: false },
+};
+export default meta;
+
+type Story = StoryObj<Props>;
+
+export const Single: Story = {};
+export const Multiple: Story = { args: { multiple: true } };
+export const WithCrop: Story = { args: { accept: 'image/*' } };

--- a/my-app/src/library/tests/FileUploader.test.tsx
+++ b/my-app/src/library/tests/FileUploader.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { FileUploader, FileUploaderRef } from '../components/inputs/FileUploader';
+
+declare const global: any;
+
+global.URL.createObjectURL = jest.fn(() => 'preview');
+
+HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+  drawImage: jest.fn(),
+})) as any;
+HTMLCanvasElement.prototype.toBlob = function (cb: (b: Blob) => void) {
+  cb(new Blob(['x'], { type: 'image/png' }));
+};
+
+describe('FileUploader', () => {
+  it('handles file drop', async () => {
+    const onUpload = jest.fn();
+    const file = new File(['1'], 'a.png', { type: 'image/png' });
+    const { getByText, getByRole } = render(
+      <FileUploader name="f" onUpload={onUpload} />,
+    );
+    const dropArea = getByText(/drag/i).parentElement as HTMLElement;
+    fireEvent.drop(dropArea, { dataTransfer: { files: [file] } });
+    await waitFor(() => expect(onUpload).toHaveBeenCalled());
+    expect(getByRole('list').children).toHaveLength(1);
+  });
+
+  it('removes file via ref', async () => {
+    const file = new File(['1'], 'b.png', { type: 'image/png' });
+    const ref = React.createRef<FileUploaderRef>();
+    const { getByText, getByRole } = render(<FileUploader name="f" ref={ref} />);
+    const dropArea = getByText(/drag/i).parentElement as HTMLElement;
+    fireEvent.drop(dropArea, { dataTransfer: { files: [file] } });
+    await waitFor(() => expect(getByRole('list').children).toHaveLength(1));
+    ref.current!.removeFile(file);
+    await waitFor(() => expect(getByRole('list').children).toHaveLength(0));
+  });
+
+  it('crop workflow', async () => {
+    const file = new File(['1'], 'c.png', { type: 'image/png' });
+    const { getByText, getByLabelText, queryByLabelText } = render(
+      <FileUploader name="f" />,
+    );
+    const dropArea = getByText(/drag/i).parentElement as HTMLElement;
+    fireEvent.drop(dropArea, { dataTransfer: { files: [file] } });
+    await waitFor(() => expect(getByLabelText(`Crop ${file.name}`)).toBeInTheDocument());
+    fireEvent.click(getByLabelText(`Crop ${file.name}`));
+    await waitFor(() => expect(getByLabelText('Apply crop')).toBeInTheDocument());
+    fireEvent.click(getByLabelText('Apply crop'));
+    await waitFor(() => expect(queryByLabelText('Apply crop')).not.toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Summary
- create reusable FileUploader input with drag & drop
- generate thumbnails and crop images
- export new component
- add Jest tests for upload, remove, crop
- add Storybook story for FileUploader

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a13fda8048321843adf1caefffb8b