### PR TITLE
Implement advanced input components

### DIFF
--- a/my-app/src/library/components/inputs/Autocomplete.tsx
+++ b/my-app/src/library/components/inputs/Autocomplete.tsx
@@ -3,148 +3,151 @@ import { AnimatePresence, motion } from 'framer-motion';
 import clsx from 'clsx';
 import { useDebounce } from './useDebounce';
 
-export interface AutocompleteProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
-  optionsFetcher: string | ((q: string) => Promise<string[]>);
+export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  optionsFetcher: string | ((query: string) => Promise<any[]>);
   debounce?: number;
   minChars?: number;
   value?: string;
-  onChange?: (value: string) => void;
+  onChange: (val: string) => void;
   className?: string;
 }
 
-export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps>(
-  function Autocomplete(
-    {
-      optionsFetcher,
-      debounce = 300,
-      minChars = 1,
-      value,
-      onChange,
-      className,
-      ...rest
-    },
-    ref,
-  ) {
-    const inputRef = useRef<HTMLInputElement>(null);
-    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
-
-    const [query, setQuery] = useState(value ?? '');
-    const [suggestions, setSuggestions] = useState<string[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [open, setOpen] = useState(false);
-    const [active, setActive] = useState(-1);
-    const cache = useRef<Record<string, string[]>>({});
-
-    const debouncedQuery = useDebounce(query, debounce);
-
-    useEffect(() => setQuery(value ?? ''), [value]);
-
-    useEffect(() => {
-      const fetchOptions = async (q: string) => {
-        if (cache.current[q]) {
-          setSuggestions(cache.current[q]);
-          return;
-        }
-        setLoading(true);
-        try {
-          let opts: string[] = [];
-          if (typeof optionsFetcher === 'string') {
-            const res = await fetch(`${optionsFetcher}?q=${encodeURIComponent(q)}`);
-            opts = await res.json();
-          } else {
-            opts = await optionsFetcher(q);
-          }
-          cache.current[q] = opts;
-          setSuggestions(opts);
-        } finally {
-          setLoading(false);
-        }
-      };
-
-      if (debouncedQuery.length >= minChars) {
-        fetchOptions(debouncedQuery);
-        setOpen(true);
-      } else {
-        setOpen(false);
-        setSuggestions([]);
-      }
-    }, [debouncedQuery, minChars, optionsFetcher]);
-
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setQuery(e.target.value);
-      onChange?.(e.target.value);
-    };
-
-    const selectOption = (option: string) => {
-      setQuery(option);
-      onChange?.(option);
-      setOpen(false);
-    };
-
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (!open) return;
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setActive((a) => (a + 1) % suggestions.length);
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setActive((a) => (a - 1 + suggestions.length) % suggestions.length);
-      } else if (e.key === 'Enter') {
-        if (active >= 0 && suggestions[active]) {
-          e.preventDefault();
-          selectOption(suggestions[active]);
-        }
-      }
-    };
-
-    return (
-      <div className={clsx('relative', className)}>
-        <input
-          ref={inputRef}
-          value={query}
-          onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
-          onFocus={() => query.length >= minChars && setOpen(true)}
-          role="combobox"
-          aria-expanded={open}
-          aria-activedescendant={active >= 0 ? `ac-item-${active}` : undefined}
-          className="w-full border rounded p-2"
-          {...rest}
-        />
-        {loading && (
-          <div className="absolute right-2 top-1/2 -translate-y-1/2 animate-spin" data-testid="loading">
-            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <circle cx="12" cy="12" r="10" strokeWidth="4" className="opacity-25" />
-              <path d="M4 12a8 8 0 018-8" strokeWidth="4" className="opacity-75" />
-            </svg>
-          </div>
-        )}
-        <AnimatePresence>
-          {open && suggestions.length > 0 && (
-            <motion.ul
-              initial={{ opacity: 0, y: -5 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -5 }}
-              className="absolute z-10 mt-1 w-full rounded border bg-white shadow"
-            >
-              {suggestions.map((opt, idx) => (
-                <li
-                  id={`ac-item-${idx}`}
-                  key={opt}
-                  role="option"
-                  aria-selected={idx === active}
-                  className={clsx('cursor-pointer p-2', idx === active && 'bg-gray-200')}
-                  onMouseDown={() => selectOption(opt)}
-                  onMouseEnter={() => setActive(idx)}
-                >
-                  {opt}
-                </li>
-              ))}
-            </motion.ul>
-          )}
-        </AnimatePresence>
-      </div>
-    );
+export const Autocomplete = React.forwardRef<HTMLInputElement, Props>(function Autocomplete(
+  {
+    optionsFetcher,
+    debounce = 300,
+    minChars = 1,
+    value,
+    onChange,
+    className,
+    ...rest
   },
-);
+  ref,
+) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState(value ?? '');
+  const [options, setOptions] = useState<any[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [active, setActive] = useState(-1);
+  const cache = useRef<Record<string, any[]>>({});
+
+  const debounced = useDebounce(query, debounce);
+
+  useEffect(() => {
+    setQuery(value ?? '');
+  }, [value]);
+
+  useEffect(() => {
+    const fetchOptions = async (q: string) => {
+      if (cache.current[q]) {
+        setOptions(cache.current[q]);
+        return;
+      }
+      setLoading(true);
+      try {
+        let result: any[] = [];
+        if (typeof optionsFetcher === 'string') {
+          const res = await fetch(`${optionsFetcher}?q=${encodeURIComponent(q)}`);
+          result = await res.json();
+        } else {
+          result = await optionsFetcher(q);
+        }
+        cache.current[q] = result;
+        setOptions(result);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (debounced.length >= minChars) {
+      fetchOptions(debounced);
+      setOpen(true);
+    } else {
+      setOpen(false);
+      setOptions([]);
+    }
+  }, [debounced, minChars, optionsFetcher]);
+
+  const selectOption = (val: string) => {
+    setQuery(val);
+    onChange(val);
+    setOpen(false);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+    onChange(e.target.value);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((prev) => (prev + 1) % options.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((prev) => (prev - 1 + options.length) % options.length);
+    } else if (e.key === 'Enter') {
+      if (active >= 0 && options[active]) {
+        e.preventDefault();
+        selectOption(String(options[active]));
+      }
+    }
+  };
+
+  return (
+    <div className={clsx('relative', className)}>
+      <input
+        ref={(node) => {
+          inputRef.current = node;
+          if (typeof ref === 'function') ref(node);
+          else if (ref) (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
+        }}
+        value={query}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => query.length >= minChars && setOpen(true)}
+        role="combobox"
+        aria-expanded={open}
+        aria-activedescendant={active >= 0 ? `ac-item-${active}` : undefined}
+        className="w-full rounded border p-2 focus:outline-none"
+        {...rest}
+      />
+      {loading && (
+        <div className="absolute right-2 top-1/2 -translate-y-1/2 animate-spin" data-testid="loading">
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" className="opacity-25" />
+            <path d="M4 12a8 8 0 018-8" className="opacity-75" />
+          </svg>
+        </div>
+      )}
+      <AnimatePresence>
+        {open && options.length > 0 && (
+          <motion.ul
+            initial={{ opacity: 0, y: -5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -5 }}
+            className="absolute z-10 mt-1 w-full rounded border bg-white shadow"
+          >
+            {options.map((opt, idx) => (
+              <li
+                key={idx}
+                id={`ac-item-${idx}`}
+                role="option"
+                aria-selected={idx === active}
+                className={clsx('cursor-pointer p-2', idx === active && 'bg-gray-200')}
+                onMouseDown={() => selectOption(String(opt))}
+                onMouseEnter={() => setActive(idx)}
+              >
+                {String(opt)}
+              </li>
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+});
+
+export default Autocomplete;

--- a/my-app/src/library/components/inputs/MaskedInput.tsx
+++ b/my-app/src/library/components/inputs/MaskedInput.tsx
@@ -1,91 +1,92 @@
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
-export interface MaskedInputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   maskPattern: string;
   maskChar?: string;
   value?: string;
   defaultValue?: string;
-  onChange?: (val: string) => void;
+  onChange: (val: string) => void;
   className?: string;
 }
 
-function applyMask(pattern: string, maskChar: string, value: string) {
+function applyMask(pattern: string, char: string, value: string) {
   const digits = value.replace(/[^\w]/g, '');
   let result = '';
   let di = 0;
-  for (const ch of pattern) {
-    if (ch === '#') {
-      result += digits[di] ?? maskChar;
+  for (const p of pattern) {
+    if (p === '#') {
+      result += digits[di] ?? char;
       di += 1;
     } else {
-      result += ch;
+      result += p;
     }
   }
   return result;
 }
 
-export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
-  function MaskedInput(
-    {
-      maskPattern,
-      maskChar = '_',
-      value,
-      defaultValue = '',
-      onChange,
-      className,
-      ...rest
-    },
-    ref,
-  ) {
-    const inputRef = useRef<HTMLInputElement>(null);
-    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
-
-    const isControlled = value !== undefined;
-    const [internal, setInternal] = useState(defaultValue);
-    const val = isControlled ? value! : internal;
-
-    const masked = applyMask(maskPattern, maskChar, val);
-
-    useEffect(() => {
-      if (!isControlled) setInternal(defaultValue);
-    }, [defaultValue, isControlled]);
-
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const raw = e.target.value.replace(/[^\w]/g, '');
-      if (!isControlled) setInternal(raw);
-      onChange?.(raw);
-    };
-
-    const clear = () => {
-      if (!isControlled) setInternal('');
-      onChange?.('');
-    };
-
-    return (
-      <div className={clsx('relative inline-flex items-center', className)}>
-        <input
-          ref={inputRef}
-          value={masked}
-          onChange={handleChange}
-          aria-label={rest['aria-label']}
-          aria-invalid={rest['aria-invalid']}
-          className="border rounded p-2 pr-6"
-          {...rest}
-        />
-        {val && (
-          <button
-            type="button"
-            onClick={clear}
-            className="absolute right-1 text-gray-500"
-            tabIndex={-1}
-            aria-label="Clear"
-          >
-            ×
-          </button>
-        )}
-      </div>
-    );
+export const MaskedInput = React.forwardRef<HTMLInputElement, Props>(function MaskedInput(
+  {
+    maskPattern,
+    maskChar = '_',
+    value,
+    defaultValue = '',
+    onChange,
+    className,
+    ...rest
   },
-);
+  ref,
+) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = useState(defaultValue);
+
+  useEffect(() => {
+    if (!isControlled) setInternal(defaultValue);
+  }, [defaultValue, isControlled]);
+
+  const rawValue = isControlled ? value! : internal;
+  const masked = applyMask(maskPattern, maskChar, rawValue);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/[^\w]/g, '');
+    if (!isControlled) setInternal(raw);
+    onChange(raw);
+  };
+
+  const clear = () => {
+    if (!isControlled) setInternal('');
+    onChange('');
+  };
+
+  return (
+    <div className={clsx('relative inline-flex items-center', className)}>
+      <input
+        ref={(node) => {
+          inputRef.current = node;
+          if (typeof ref === 'function') ref(node);
+          else if (ref) (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
+        }}
+        value={masked}
+        onChange={handleChange}
+        aria-label={rest['aria-label']}
+        aria-invalid={rest['aria-invalid']}
+        className="w-full rounded border p-2 pr-6 focus:outline-none"
+        {...rest}
+      />
+      {rawValue && (
+        <button
+          type="button"
+          onClick={clear}
+          tabIndex={-1}
+          className="absolute right-1 text-gray-500"
+          aria-label="Clear"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+});
+
+export default MaskedInput;

--- a/my-app/src/library/components/inputs/Rating.tsx
+++ b/my-app/src/library/components/inputs/Rating.tsx
@@ -2,15 +2,21 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import clsx from 'clsx';
 
-export interface RatingProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   max?: number;
   value?: number;
   defaultValue?: number;
-  onChange?: (val: number) => void;
+  onChange: (val: number) => void;
   readOnly?: boolean;
-  size?: number;
+  size?: 'sm' | 'md' | 'lg';
   className?: string;
 }
+
+const sizeMap: Record<NonNullable<Props['size']>, number> = {
+  sm: 16,
+  md: 24,
+  lg: 32,
+};
 
 const Star = ({ filled, size }: { filled: boolean; size: number }) => (
   <svg
@@ -21,64 +27,60 @@ const Star = ({ filled, size }: { filled: boolean; size: number }) => (
     stroke="currentColor"
     strokeWidth="2"
   >
-    <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+    <path d="M12 17.27L18.18 21 16.54 13.97 22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z" />
   </svg>
 );
 
-export const Rating = React.forwardRef<HTMLDivElement, RatingProps>(
-  function Rating(
-    {
-      max = 5,
-      value,
-      defaultValue = 0,
-      onChange,
-      readOnly = false,
-      size = 24,
-      className,
-      ...rest
-    },
-    ref,
-  ) {
-    const isControlled = value !== undefined;
-    const [internal, setInternal] = useState(defaultValue);
-    const [hover, setHover] = useState(0);
-
-    const rating = isControlled ? value! : internal;
-
-    const handleSelect = (i: number) => {
-      if (readOnly) return;
-      if (!isControlled) setInternal(i);
-      onChange?.(i);
-    };
-
-    return (
-      <div
-        ref={ref}
-        role="radiogroup"
-        className={clsx('inline-flex', className)}
-        {...rest}
-      >
-        {Array.from({ length: max }).map((_, idx) => {
-          const index = idx + 1;
-          const filled = hover ? index <= hover : index <= rating;
-          return (
-            <motion.button
-              type="button"
-              key={index}
-              role="radio"
-              aria-checked={index === rating}
-              className="p-1"
-              onMouseEnter={() => !readOnly && setHover(index)}
-              onMouseLeave={() => !readOnly && setHover(0)}
-              onClick={() => handleSelect(index)}
-              whileHover={!readOnly ? { scale: 1.2 } : undefined}
-              whileTap={!readOnly ? { scale: 0.9 } : undefined}
-            >
-              <Star filled={filled} size={size} />
-            </motion.button>
-          );
-        })}
-      </div>
-    );
+export const Rating = React.forwardRef<HTMLDivElement, Props>(function Rating(
+  {
+    max = 5,
+    value,
+    defaultValue = 0,
+    onChange,
+    readOnly = false,
+    size = 'md',
+    className,
+    ...rest
   },
-);
+  ref,
+) {
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = useState(defaultValue);
+  const [hover, setHover] = useState(0);
+
+  const rating = isControlled ? value! : internal;
+  const starSize = sizeMap[size];
+
+  const select = (val: number) => {
+    if (readOnly) return;
+    if (!isControlled) setInternal(val);
+    onChange(val);
+  };
+
+  return (
+    <div ref={ref} role="radiogroup" className={clsx('inline-flex', className)} {...rest}>
+      {Array.from({ length: max }).map((_, idx) => {
+        const index = idx + 1;
+        const filled = hover ? index <= hover : index <= rating;
+        return (
+          <motion.button
+            key={index}
+            type="button"
+            role="radio"
+            aria-checked={index === rating}
+            className="p-1"
+            onMouseEnter={() => !readOnly && setHover(index)}
+            onMouseLeave={() => !readOnly && setHover(0)}
+            onClick={() => select(index)}
+            whileHover={!readOnly ? { scale: 1.2 } : undefined}
+            whileTap={!readOnly ? { scale: 0.9 } : undefined}
+          >
+            <Star filled={filled} size={starSize} />
+          </motion.button>
+        );
+      })}
+    </div>
+  );
+});
+
+export default Rating;

--- a/my-app/src/library/stories/Autocomplete.stories.tsx
+++ b/my-app/src/library/stories/Autocomplete.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Autocomplete, AutocompleteProps } from '../components/inputs/Autocomplete';
+import Autocomplete, { Props as AutocompleteProps } from '../components/inputs/Autocomplete';
 
 const meta: Meta<AutocompleteProps> = {
   title: 'library/Inputs/Autocomplete',
@@ -12,10 +12,11 @@ const meta: Meta<AutocompleteProps> = {
     className: { control: 'text' },
   },
   args: {
-    optionsFetcher: async (q: string) => ['apple', 'banana', 'orange'].filter((o) => o.includes(q)),
+    optionsFetcher: async (q: string) => ['apple', 'banana', 'orange'].filter(o => o.includes(q)),
     debounce: 300,
     minChars: 1,
     value: '',
+    onChange: () => {},
   },
 };
 export default meta;

--- a/my-app/src/library/stories/MaskedInput.stories.tsx
+++ b/my-app/src/library/stories/MaskedInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { MaskedInput, MaskedInputProps } from '../components/inputs/MaskedInput';
+import MaskedInput, { Props as MaskedInputProps } from '../components/inputs/MaskedInput';
 
 const meta: Meta<MaskedInputProps> = {
   title: 'library/Inputs/MaskedInput',
@@ -15,6 +15,7 @@ const meta: Meta<MaskedInputProps> = {
     maskPattern: '###-###',
     maskChar: '_',
     defaultValue: '',
+    onChange: () => {},
   },
 };
 export default meta;

--- a/my-app/src/library/stories/Rating.stories.tsx
+++ b/my-app/src/library/stories/Rating.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Rating, RatingProps } from '../components/inputs/Rating';
+import Rating, { Props as RatingProps } from '../components/inputs/Rating';
 
 const meta: Meta<RatingProps> = {
   title: 'library/Inputs/Rating',
@@ -9,14 +9,15 @@ const meta: Meta<RatingProps> = {
     value: { control: 'number' },
     defaultValue: { control: 'number' },
     readOnly: { control: 'boolean' },
-    size: { control: 'number' },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
     className: { control: 'text' },
   },
   args: {
     max: 5,
     defaultValue: 3,
     readOnly: false,
-    size: 24,
+    size: 'md',
+    onChange: () => {},
   },
 };
 export default meta;

--- a/my-app/src/library/tests/Autocomplete.test.tsx
+++ b/my-app/src/library/tests/Autocomplete.test.tsx
@@ -5,7 +5,7 @@ describe('Autocomplete', () => {
   it('fetches suggestions as user types', async () => {
     const fetcher = jest.fn(async () => ['one']);
     const { getByRole } = render(
-      <Autocomplete optionsFetcher={fetcher} debounce={0} />,
+      <Autocomplete optionsFetcher={fetcher} debounce={0} onChange={() => {}} />,
     );
     fireEvent.change(getByRole('combobox'), { target: { value: 'o' } });
     await waitFor(() => expect(fetcher).toHaveBeenCalledWith('o'));
@@ -14,7 +14,7 @@ describe('Autocomplete', () => {
   it('allows keyboard navigation and selection', async () => {
     const fetcher = jest.fn(async () => ['a', 'b']);
     const { getByRole, getByText } = render(
-      <Autocomplete optionsFetcher={fetcher} debounce={0} minChars={0} />,
+      <Autocomplete optionsFetcher={fetcher} debounce={0} minChars={0} onChange={() => {}} />,
     );
     const input = getByRole('combobox') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '' } });
@@ -28,7 +28,7 @@ describe('Autocomplete', () => {
   it('selects option on click', async () => {
     const fetcher = jest.fn(async () => ['foo', 'bar']);
     const { getByRole, getByText } = render(
-      <Autocomplete optionsFetcher={fetcher} debounce={0} minChars={0} />,
+      <Autocomplete optionsFetcher={fetcher} debounce={0} minChars={0} onChange={() => {}} />,
     );
     const input = getByRole('combobox') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '' } });

--- a/my-app/src/library/tests/MaskedInput.test.tsx
+++ b/my-app/src/library/tests/MaskedInput.test.tsx
@@ -4,7 +4,7 @@ import { MaskedInput } from '../components/inputs/MaskedInput';
 describe('MaskedInput', () => {
   it('applies mask pattern', () => {
     const { getByLabelText } = render(
-      <MaskedInput maskPattern="###-###" aria-label="m" />,
+      <MaskedInput maskPattern="###-###" aria-label="m" onChange={() => {}} />,
     );
     const input = getByLabelText('m') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '12345' } });
@@ -13,7 +13,7 @@ describe('MaskedInput', () => {
 
   it('handles paste input', () => {
     const { getByLabelText } = render(
-      <MaskedInput maskPattern="###-###" aria-label="m" />,
+      <MaskedInput maskPattern="###-###" aria-label="m" onChange={() => {}} />,
     );
     const input = getByLabelText('m') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '123456' } });

--- a/my-app/src/library/tests/Rating.test.tsx
+++ b/my-app/src/library/tests/Rating.test.tsx
@@ -3,7 +3,7 @@ import { Rating } from '../components/inputs/Rating';
 
 describe('Rating', () => {
   it('changes highlight on hover', () => {
-    const { getAllByRole } = render(<Rating />);
+    const { getAllByRole } = render(<Rating onChange={() => {}} />);
     const stars = getAllByRole('radio');
     fireEvent.mouseEnter(stars[2]);
     expect(stars[2].querySelector('svg')?.getAttribute('fill')).toBe('currentColor');


### PR DESCRIPTION
## Summary
- refactor Autocomplete with debounced fetching, caching, framer-motion dropdown
- rebuild MaskedInput to format input with clear button
- enhance Rating component with sizing and animated stars
- update unit tests
- create Storybook stories for new props

## Testing
- `npx jest --runInBand` *(fails: `jest` not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686a212429b083218ebd6139038b7398