### PR TITLE
Add modal components with tests and stories

### DIFF
--- a/my-app/src/app/components/modals/AlertDialog.tsx
+++ b/my-app/src/app/components/modals/AlertDialog.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface AlertDialogProps extends Omit<ModalProps, 'footer'> {
+  confirmLabel?: string;
+}
+
+export const AlertDialog: React.FC<AlertDialogProps> = ({
+  confirmLabel = 'OK',
+  onClose,
+  ...props
+}) => (
+  <Modal
+    {...props}
+    onClose={onClose}
+    footer={<Button onClick={onClose}>{confirmLabel}</Button>}
+  />
+);

--- a/my-app/src/app/components/modals/ConfirmDialog.tsx
+++ b/my-app/src/app/components/modals/ConfirmDialog.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface ConfirmDialogProps extends Omit<ModalProps, 'footer'> {
+  onConfirm: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  onConfirm,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  onClose,
+  ...props
+}) => (
+  <Modal
+    {...props}
+    onClose={onClose}
+    footer={
+      <>
+        <Button variant="secondary" onClick={onClose}>
+          {cancelLabel}
+        </Button>
+        <Button onClick={onConfirm}>{confirmLabel}</Button>
+      </>
+    }
+  />
+);

--- a/my-app/src/app/components/modals/Drawer.tsx
+++ b/my-app/src/app/components/modals/Drawer.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+
+export const Drawer: React.FC<ModalProps> = ({ placement = 'left', ...props }) => (
+  <Modal {...props} placement={placement} />
+);

--- a/my-app/src/app/components/modals/ErrorModal.tsx
+++ b/my-app/src/app/components/modals/ErrorModal.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface ErrorModalProps extends Omit<ModalProps, 'footer'> {
+  message: string;
+}
+
+export const ErrorModal: React.FC<ErrorModalProps> = ({ message, onClose, ...props }) => (
+  <Modal {...props} onClose={onClose} footer={<Button onClick={onClose}>Close</Button>}>
+    <div className="text-red-600 text-center p-4">{message}</div>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/FormDialog.tsx
+++ b/my-app/src/app/components/modals/FormDialog.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface FormDialogProps extends Omit<ModalProps, 'footer'> {
+  onSubmit: (e: React.FormEvent) => void;
+  submitLabel?: string;
+  cancelLabel?: string;
+}
+
+export const FormDialog: React.FC<FormDialogProps> = ({
+  onSubmit,
+  submitLabel = 'Submit',
+  cancelLabel = 'Cancel',
+  onClose,
+  children,
+  ...props
+}) => (
+  <Modal
+    {...props}
+    onClose={onClose}
+    footer={
+      <>
+        <Button variant="secondary" onClick={onClose}>
+          {cancelLabel}
+        </Button>
+        <Button type="submit" form="dialog-form">
+          {submitLabel}
+        </Button>
+      </>
+    }
+  >
+    <form id="dialog-form" onSubmit={onSubmit} className="space-y-4">
+      {children}
+    </form>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/FullscreenModal.tsx
+++ b/my-app/src/app/components/modals/FullscreenModal.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+
+export const FullscreenModal: React.FC<ModalProps> = ({ children, ...props }) => (
+  <Modal {...props} placement="top">
+    <div className="h-screen overflow-auto">{children}</div>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/ImagePreviewModal.tsx
+++ b/my-app/src/app/components/modals/ImagePreviewModal.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface ImagePreviewModalProps extends Omit<ModalProps, 'children'> {
+  src: string;
+}
+
+export const ImagePreviewModal: React.FC<ImagePreviewModalProps> = ({
+  src,
+  onClose,
+  ...props
+}) => {
+  const [zoom, setZoom] = useState(1);
+  return (
+    <Modal
+      {...props}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="secondary" onClick={() => setZoom((z) => Math.max(1, z - 0.25))}>
+            -
+          </Button>
+          <Button variant="secondary" onClick={() => setZoom((z) => z + 0.25)}>
+            +
+          </Button>
+          <Button onClick={onClose}>Close</Button>
+        </>
+      }
+    >
+      <div className="flex justify-center overflow-auto">
+        <img src={src} alt={props.title ?? ''} style={{ transform: `scale(${zoom})` }} />
+      </div>
+    </Modal>
+  );
+};

--- a/my-app/src/app/components/modals/LoadingModal.tsx
+++ b/my-app/src/app/components/modals/LoadingModal.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+
+export const LoadingModal: React.FC<ModalProps> = (props) => (
+  <Modal {...props} footer={null}>
+    <div className="flex items-center justify-center p-8">
+      <div className="animate-spin rounded-full h-8 w-8 border-4 border-blue-600 border-t-transparent" />
+    </div>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/Modal.tsx
+++ b/my-app/src/app/components/modals/Modal.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef } from 'react';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+  footer?: React.ReactNode;
+  placement?: 'left' | 'right' | 'top' | 'bottom';
+  children?: React.ReactNode;
+}
+
+/** Basic accessible modal dialog */
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  description,
+  footer,
+  placement = 'bottom',
+  children,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    // focus trap start
+    const firstFocusable = ref.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    firstFocusable?.focus();
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const placementClasses: Record<string, string> = {
+    bottom: 'items-end',
+    top: 'items-start',
+    left: 'justify-start',
+    right: 'justify-end',
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex ${placementClasses[placement]} justify-center`}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? 'modal-title' : undefined}
+      aria-describedby={description ? 'modal-desc' : undefined}
+    >
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} data-testid="backdrop" />
+      <div
+        ref={ref}
+        tabIndex={-1}
+        className="relative bg-white dark:bg-gray-800 rounded shadow-lg max-w-lg w-full p-4 m-4 focus:outline-none"
+      >
+        {title && (
+          <h2 id="modal-title" className="text-lg font-semibold mb-2">
+            {title}
+          </h2>
+        )}
+        {description && (
+          <p id="modal-desc" className="mb-4 text-sm text-gray-600 dark:text-gray-300">
+            {description}
+          </p>
+        )}
+        <div>{children}</div>
+        {footer && <div className="mt-4 flex justify-end gap-2">{footer}</div>}
+      </div>
+    </div>
+  );
+};

--- a/my-app/src/app/components/modals/PermissionModal.tsx
+++ b/my-app/src/app/components/modals/PermissionModal.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface PermissionModalProps extends Omit<ModalProps, 'footer'> {
+  message: string;
+}
+
+export const PermissionModal: React.FC<PermissionModalProps> = ({ message, onClose, ...props }) => (
+  <Modal {...props} onClose={onClose} footer={<Button onClick={onClose}>Close</Button>}>
+    <p>{message}</p>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/SessionExpiredModal.tsx
+++ b/my-app/src/app/components/modals/SessionExpiredModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface SessionExpiredModalProps extends Omit<ModalProps, 'footer'> {
+  onRedirect: () => void;
+}
+
+export const SessionExpiredModal: React.FC<SessionExpiredModalProps> = ({
+  onRedirect,
+  onClose,
+  ...props
+}) => (
+  <Modal
+    {...props}
+    onClose={onClose}
+    footer={
+      <>
+        <Button variant="secondary" onClick={onClose}>
+          Close
+        </Button>
+        <Button onClick={onRedirect}>Login</Button>
+      </>
+    }
+  >
+    <p>Your session has expired.</p>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/SuccessModal.tsx
+++ b/my-app/src/app/components/modals/SuccessModal.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface SuccessModalProps extends Omit<ModalProps, 'footer'> {
+  message: string;
+}
+
+export const SuccessModal: React.FC<SuccessModalProps> = ({ message, onClose, ...props }) => (
+  <Modal {...props} onClose={onClose} footer={<Button onClick={onClose}>Close</Button>}>
+    <div className="text-green-600 text-center p-4">{message}</div>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/UpdateAvailableModal.tsx
+++ b/my-app/src/app/components/modals/UpdateAvailableModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface UpdateAvailableModalProps extends Omit<ModalProps, 'footer'> {
+  onUpdate: () => void;
+}
+
+export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({
+  onUpdate,
+  onClose,
+  ...props
+}) => (
+  <Modal
+    {...props}
+    onClose={onClose}
+    footer={
+      <>
+        <Button variant="secondary" onClick={onClose}>
+          Later
+        </Button>
+        <Button onClick={onUpdate}>Update</Button>
+      </>
+    }
+  >
+    <p>An update is available.</p>
+  </Modal>
+);

--- a/my-app/src/app/components/modals/VideoModal.tsx
+++ b/my-app/src/app/components/modals/VideoModal.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '@app/components/ui/Button';
+
+export interface VideoModalProps extends Omit<ModalProps, 'children'> {
+  src: string;
+}
+
+export const VideoModal: React.FC<VideoModalProps> = ({ src, onClose, ...props }) => (
+  <Modal {...props} onClose={onClose} footer={<Button onClick={onClose}>Close</Button>}>
+    <video src={src} controls className="w-full rounded" />
+  </Modal>
+);

--- a/my-app/src/app/components/modals/index.ts
+++ b/my-app/src/app/components/modals/index.ts
@@ -1,1 +1,14 @@
-
+export * from './Modal';
+export * from './AlertDialog';
+export * from './ConfirmDialog';
+export * from './FormDialog';
+export * from './Drawer';
+export * from './ImagePreviewModal';
+export * from './VideoModal';
+export * from './FullscreenModal';
+export * from './LoadingModal';
+export * from './SuccessModal';
+export * from './ErrorModal';
+export * from './SessionExpiredModal';
+export * from './PermissionModal';
+export * from './UpdateAvailableModal';

--- a/my-app/src/app/components/stories/AlertDialog.stories.tsx
+++ b/my-app/src/app/components/stories/AlertDialog.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { AlertDialog } from '@app/components/modals/AlertDialog';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof AlertDialog> = {
+  title: 'modals/AlertDialog',
+  component: AlertDialog,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof AlertDialog> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <AlertDialog isOpen={open} onClose={() => setOpen(false)} title="Alert" description="Something happened" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/ConfirmDialog.stories.tsx
+++ b/my-app/src/app/components/stories/ConfirmDialog.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { ConfirmDialog } from '@app/components/modals/ConfirmDialog';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: 'modals/ConfirmDialog',
+  component: ConfirmDialog,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof ConfirmDialog> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <ConfirmDialog isOpen={open} onClose={() => setOpen(false)} onConfirm={() => setOpen(false)} title="Confirm" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/DrawerModal.stories.tsx
+++ b/my-app/src/app/components/stories/DrawerModal.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Drawer } from '@app/components/modals/Drawer';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof Drawer> = {
+  title: 'modals/Drawer',
+  component: Drawer,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof Drawer> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <Drawer isOpen={open} onClose={() => setOpen(false)} placement="left">
+          Drawer Content
+        </Drawer>
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/ErrorModal.stories.tsx
+++ b/my-app/src/app/components/stories/ErrorModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { ErrorModal } from '@app/components/modals/ErrorModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof ErrorModal> = {
+  title: 'modals/ErrorModal',
+  component: ErrorModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof ErrorModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <ErrorModal isOpen={open} onClose={() => setOpen(false)} message="Error" title="Error" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/FormDialog.stories.tsx
+++ b/my-app/src/app/components/stories/FormDialog.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { FormDialog } from '@app/components/modals/FormDialog';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof FormDialog> = {
+  title: 'modals/FormDialog',
+  component: FormDialog,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof FormDialog> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <FormDialog isOpen={open} onClose={() => setOpen(false)} onSubmit={(e) => { e.preventDefault(); setOpen(false); }} title="Form">
+          <input className="border p-2" placeholder="Name" />
+        </FormDialog>
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/FullscreenModal.stories.tsx
+++ b/my-app/src/app/components/stories/FullscreenModal.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { FullscreenModal } from '@app/components/modals/FullscreenModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof FullscreenModal> = {
+  title: 'modals/FullscreenModal',
+  component: FullscreenModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof FullscreenModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <FullscreenModal isOpen={open} onClose={() => setOpen(false)} title="Full Screen">
+          Content
+        </FullscreenModal>
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/ImagePreviewModal.stories.tsx
+++ b/my-app/src/app/components/stories/ImagePreviewModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { ImagePreviewModal } from '@app/components/modals/ImagePreviewModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof ImagePreviewModal> = {
+  title: 'modals/ImagePreviewModal',
+  component: ImagePreviewModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof ImagePreviewModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <ImagePreviewModal isOpen={open} onClose={() => setOpen(false)} src="https://via.placeholder.com/300" title="Image" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/LoadingModal.stories.tsx
+++ b/my-app/src/app/components/stories/LoadingModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { LoadingModal } from '@app/components/modals/LoadingModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof LoadingModal> = {
+  title: 'modals/LoadingModal',
+  component: LoadingModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof LoadingModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <LoadingModal isOpen={open} onClose={() => setOpen(false)} title="Loading" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/Modal.stories.tsx
+++ b/my-app/src/app/components/stories/Modal.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Modal } from '@app/components/modals/Modal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof Modal> = {
+  title: 'modals/Modal',
+  component: Modal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof Modal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <Modal isOpen={open} onClose={() => setOpen(false)} title="Modal">
+          Content
+        </Modal>
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/PermissionModal.stories.tsx
+++ b/my-app/src/app/components/stories/PermissionModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { PermissionModal } from '@app/components/modals/PermissionModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof PermissionModal> = {
+  title: 'modals/PermissionModal',
+  component: PermissionModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof PermissionModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <PermissionModal isOpen={open} onClose={() => setOpen(false)} message="Permission denied" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/SessionExpiredModal.stories.tsx
+++ b/my-app/src/app/components/stories/SessionExpiredModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { SessionExpiredModal } from '@app/components/modals/SessionExpiredModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof SessionExpiredModal> = {
+  title: 'modals/SessionExpiredModal',
+  component: SessionExpiredModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof SessionExpiredModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <SessionExpiredModal isOpen={open} onClose={() => setOpen(false)} onRedirect={() => setOpen(false)} />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/SuccessModal.stories.tsx
+++ b/my-app/src/app/components/stories/SuccessModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { SuccessModal } from '@app/components/modals/SuccessModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof SuccessModal> = {
+  title: 'modals/SuccessModal',
+  component: SuccessModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof SuccessModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <SuccessModal isOpen={open} onClose={() => setOpen(false)} message="Success" title="Success" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/UpdateAvailableModal.stories.tsx
+++ b/my-app/src/app/components/stories/UpdateAvailableModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { UpdateAvailableModal } from '@app/components/modals/UpdateAvailableModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof UpdateAvailableModal> = {
+  title: 'modals/UpdateAvailableModal',
+  component: UpdateAvailableModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof UpdateAvailableModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <UpdateAvailableModal isOpen={open} onClose={() => setOpen(false)} onUpdate={() => setOpen(false)} />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/stories/VideoModal.stories.tsx
+++ b/my-app/src/app/components/stories/VideoModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { VideoModal } from '@app/components/modals/VideoModal';
+import { Button } from '@app/components/ui/Button';
+
+const meta: Meta<typeof VideoModal> = {
+  title: 'modals/VideoModal',
+  component: VideoModal,
+};
+export default meta;
+
+export const Primary: StoryObj<typeof VideoModal> = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <VideoModal isOpen={open} onClose={() => setOpen(false)} src="movie.mp4" title="Video" />
+      </>
+    );
+  },
+};

--- a/my-app/src/app/components/tests/AlertDialog.test.tsx
+++ b/my-app/src/app/components/tests/AlertDialog.test.tsx
@@ -1,0 +1,13 @@
+import { render, fireEvent } from '@testing-library/react';
+import { AlertDialog } from '@app/components/modals/AlertDialog';
+
+describe('AlertDialog', () => {
+  it('calls onClose when confirm clicked', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <AlertDialog isOpen onClose={onClose} title="Alert" />
+    );
+    fireEvent.click(getByText('OK'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/my-app/src/app/components/tests/ConfirmDialog.test.tsx
+++ b/my-app/src/app/components/tests/ConfirmDialog.test.tsx
@@ -1,0 +1,14 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ConfirmDialog } from '@app/components/modals/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('calls onConfirm when confirm clicked', () => {
+    const onConfirm = jest.fn();
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <ConfirmDialog isOpen onClose={onClose} onConfirm={onConfirm} title="Confirm" />
+    );
+    fireEvent.click(getByText('Confirm'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/my-app/src/app/components/tests/ErrorModal.test.tsx
+++ b/my-app/src/app/components/tests/ErrorModal.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { ErrorModal } from '@app/components/modals/ErrorModal';
+
+describe('ErrorModal', () => {
+  it('renders message', () => {
+    const { getByText } = render(
+      <ErrorModal isOpen onClose={() => {}} message="Error" title="Error" />
+    );
+    expect(getByText('Error')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tests/FormDialog.test.tsx
+++ b/my-app/src/app/components/tests/FormDialog.test.tsx
@@ -1,0 +1,15 @@
+import { render, fireEvent } from '@testing-library/react';
+import { FormDialog } from '@app/components/modals/FormDialog';
+
+describe('FormDialog', () => {
+  it('submits form', () => {
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    const { getByText } = render(
+      <FormDialog isOpen onClose={() => {}} onSubmit={onSubmit} title="Form">
+        <input name="test" />
+      </FormDialog>
+    );
+    fireEvent.submit(getByText('Submit').closest('form')!);
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/my-app/src/app/components/tests/FullscreenModal.test.tsx
+++ b/my-app/src/app/components/tests/FullscreenModal.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { FullscreenModal } from '@app/components/modals/FullscreenModal';
+
+describe('FullscreenModal', () => {
+  it('renders when open', () => {
+    const { getByRole } = render(
+      <FullscreenModal isOpen onClose={() => {}}>Content</FullscreenModal>
+    );
+    expect(getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tests/ImagePreviewModal.test.tsx
+++ b/my-app/src/app/components/tests/ImagePreviewModal.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { ImagePreviewModal } from '@app/components/modals/ImagePreviewModal';
+
+describe('ImagePreviewModal', () => {
+  it('renders image', () => {
+    const { getByRole } = render(
+      <ImagePreviewModal isOpen onClose={() => {}} src="img.png" title="Image" />
+    );
+    expect(getByRole('img')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tests/LoadingModal.test.tsx
+++ b/my-app/src/app/components/tests/LoadingModal.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { LoadingModal } from '@app/components/modals/LoadingModal';
+
+describe('LoadingModal', () => {
+  it('shows spinner', () => {
+    const { container } = render(
+      <LoadingModal isOpen onClose={() => {}} title="Loading" />
+    );
+    expect(container.querySelector('div.animate-spin')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tests/Modal.test.tsx
+++ b/my-app/src/app/components/tests/Modal.test.tsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Modal } from '@app/components/modals/Modal';
+
+describe('Modal', () => {
+  it('renders when open', () => {
+    const { getByRole } = render(
+      <Modal isOpen onClose={() => {}}>Content</Modal>
+    );
+    expect(getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('calls onClose on escape key', () => {
+    const onClose = jest.fn();
+    render(<Modal isOpen onClose={onClose}>Content</Modal>);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/my-app/src/app/components/tests/ModalDrawer.test.tsx
+++ b/my-app/src/app/components/tests/ModalDrawer.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import { Drawer } from '@app/components/modals/Drawer';
+
+describe('Drawer', () => {
+  it('renders when open', () => {
+    const { getByRole } = render(<Drawer isOpen onClose={() => {}}>Content</Drawer>);
+    expect(getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tests/PermissionModal.test.tsx
+++ b/my-app/src/app/components/tests/PermissionModal.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { PermissionModal } from '@app/components/modals/PermissionModal';
+
+describe('PermissionModal', () => {
+  it('renders message', () => {
+    const { getByText } = render(
+      <PermissionModal isOpen onClose={() => {}} message="Denied" />
+    );
+    expect(getByText('Denied')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tests/SessionExpiredModal.test.tsx
+++ b/my-app/src/app/components/tests/SessionExpiredModal.test.tsx
@@ -1,0 +1,13 @@
+import { render, fireEvent } from '@testing-library/react';
+import { SessionExpiredModal } from '@app/components/modals/SessionExpiredModal';
+
+describe('SessionExpiredModal', () => {
+  it('calls redirect', () => {
+    const onRedirect = jest.fn();
+    const { getByText } = render(
+      <SessionExpiredModal isOpen onClose={() => {}} onRedirect={onRedirect} />
+    );
+    fireEvent.click(getByText('Login'));
+    expect(onRedirect).toHaveBeenCalled();
+  });
+});

--- a/my-app/src/app/components/tests/SuccessModal.test.tsx
+++ b/my-app/src/app/components/tests/SuccessModal.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { SuccessModal } from '@app/components/modals/SuccessModal';
+
+describe('SuccessModal', () => {
+  it('renders message', () => {
+    const { getByText } = render(
+      <SuccessModal isOpen onClose={() => {}} message="Success" title="Success" />
+    );
+    expect(getByText('Success')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tests/UpdateAvailableModal.test.tsx
+++ b/my-app/src/app/components/tests/UpdateAvailableModal.test.tsx
@@ -1,0 +1,13 @@
+import { render, fireEvent } from '@testing-library/react';
+import { UpdateAvailableModal } from '@app/components/modals/UpdateAvailableModal';
+
+describe('UpdateAvailableModal', () => {
+  it('calls onUpdate', () => {
+    const onUpdate = jest.fn();
+    const { getByText } = render(
+      <UpdateAvailableModal isOpen onClose={() => {}} onUpdate={onUpdate} />
+    );
+    fireEvent.click(getByText('Update'));
+    expect(onUpdate).toHaveBeenCalled();
+  });
+});

--- a/my-app/src/app/components/tests/VideoModal.test.tsx
+++ b/my-app/src/app/components/tests/VideoModal.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { VideoModal } from '@app/components/modals/VideoModal';
+
+describe('VideoModal', () => {
+  it('renders video', () => {
+    const { container } = render(
+      <VideoModal isOpen onClose={() => {}} src="video.mp4" title="Video" />
+    );
+    expect(container.querySelector('video')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create a suite of modal components
- add stories for each modal
- add unit tests
- re-export modals from index

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aadcb1b2883219fa5fdcabbfaa9c0