### PR TITLE
Add advanced table components

### DIFF
--- a/my-app/src/app/components/tables/ComparisonTable.tsx
+++ b/my-app/src/app/components/tables/ComparisonTable.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { TableProps } from './types';
+
+export interface ComparisonTableProps extends TableProps {}
+
+export const ComparisonTable: React.FC<ComparisonTableProps> = ({ columns, data }) => {
+  if (!data.length) return null;
+  const baseline = data[0];
+  return (
+    <table className="min-w-full text-left" role="table">
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c.key} className="px-4 py-2">
+              {c.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, idx) => (
+          <tr key={idx} role="row" className="odd:bg-gray-50 dark:odd:bg-gray-800">
+            {columns.map((c) => (
+              <td
+                key={c.key}
+                role="gridcell"
+                className={`px-4 py-2 whitespace-nowrap ${row[c.key] !== baseline[c.key] ? 'bg-yellow-100 dark:bg-yellow-900' : ''}`}
+              >
+                {row[c.key] as React.ReactNode}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+ComparisonTable.displayName = 'ComparisonTable';

--- a/my-app/src/app/components/tables/DataGrid.tsx
+++ b/my-app/src/app/components/tables/DataGrid.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { TableProps } from './types';
+
+export interface DataGridProps extends TableProps {
+  pageSize?: number;
+}
+
+export const DataGrid: React.FC<DataGridProps> = ({
+  columns,
+  data,
+  sortable = false,
+  filterable = false,
+  pageSize = 10,
+}) => {
+  const [sortKey, setSortKey] = useState<string>();
+  const [asc, setAsc] = useState(true);
+  const [filter, setFilter] = useState('');
+  const [page, setPage] = useState(1);
+
+  const filtered = React.useMemo(() => {
+    let rows = data;
+    if (filterable && filter) {
+      const q = filter.toLowerCase();
+      rows = rows.filter((r) =>
+        Object.values(r).some((v) => String(v).toLowerCase().includes(q)),
+      );
+    }
+    if (sortable && sortKey) {
+      rows = [...rows].sort((a, b) => {
+        const av = a[sortKey];
+        const bv = b[sortKey];
+        if (av > bv) return asc ? 1 : -1;
+        if (av < bv) return asc ? -1 : 1;
+        return 0;
+      });
+    }
+    return rows;
+  }, [data, filter, filterable, sortKey, asc, sortable]);
+
+  const pages = Math.ceil(filtered.length / pageSize);
+  const paged = filtered.slice((page - 1) * pageSize, page * pageSize);
+
+  const handleHeader = (key: string, isSortable?: boolean) => {
+    if (!sortable || !isSortable) return;
+    if (sortKey === key) setAsc(!asc);
+    else {
+      setSortKey(key);
+      setAsc(true);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {filterable && (
+        <input
+          className="px-2 py-1 border rounded w-full dark:bg-gray-800"
+          placeholder="Filter..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+      )}
+      <table className="min-w-full text-left" role="table">
+        <thead>
+          <tr>
+            {columns.map((c) => (
+              <th
+                key={c.key}
+                onClick={() => handleHeader(c.key, c.sortable)}
+                className={c.sortable && sortable ? 'cursor-pointer select-none px-4 py-2' : 'px-4 py-2'}
+                aria-sort={sortKey === c.key ? (asc ? 'ascending' : 'descending') : 'none'}
+              >
+                <span className="flex items-center">
+                  {c.title}
+                  {sortable && c.sortable && sortKey === c.key && (
+                    <span className="ml-1">{asc ? '▲' : '▼'}</span>
+                  )}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {paged.map((row, idx) => (
+            <tr key={idx} role="row" className="odd:bg-gray-50 dark:odd:bg-gray-800">
+              {columns.map((c) => (
+                <td key={c.key} role="gridcell" className="px-4 py-2 whitespace-nowrap">
+                  {row[c.key] as React.ReactNode}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex items-center gap-2 justify-end">
+        <button
+          className="px-2 py-1 border rounded disabled:opacity-50"
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page === 1}
+        >
+          Prev
+        </button>
+        <span>
+          {page} / {pages}
+        </span>
+        <button
+          className="px-2 py-1 border rounded disabled:opacity-50"
+          onClick={() => setPage((p) => Math.min(pages, p + 1))}
+          disabled={page === pages}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};
+
+DataGrid.displayName = 'DataGrid';

--- a/my-app/src/app/components/tables/EditableTable.tsx
+++ b/my-app/src/app/components/tables/EditableTable.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { TableProps } from './types';
+
+export interface EditableTableProps extends TableProps {}
+
+export const EditableTable: React.FC<EditableTableProps> = ({
+  columns,
+  data,
+  onEditSave,
+}) => {
+  const [rows, setRows] = useState(() => data);
+  const [editing, setEditing] = useState<{ row: number; key: string }>();
+  const [value, setValue] = useState('');
+
+  const startEdit = (row: number, key: string, current: any) => {
+    setEditing({ row, key });
+    setValue(String(current ?? ''));
+  };
+
+  const save = () => {
+    if (!editing) return;
+    const updated = rows.map((r, i) =>
+      i === editing.row ? { ...r, [editing.key]: value } : r,
+    );
+    setRows(updated);
+    onEditSave?.(updated);
+    setEditing(undefined);
+  };
+
+  return (
+    <table className="min-w-full text-left" role="table">
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c.key} className="px-4 py-2">
+              {c.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, idx) => (
+          <tr key={idx} role="row" className="odd:bg-gray-50 dark:odd:bg-gray-800">
+            {columns.map((c) => (
+              <td key={c.key} role="gridcell" className="px-4 py-2" onDoubleClick={() => startEdit(idx, c.key, row[c.key])}>
+                {editing && editing.row === idx && editing.key === c.key ? (
+                  <input
+                    autoFocus
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                    onBlur={save}
+                    onKeyDown={(e) => e.key === 'Enter' && save()}
+                    className="px-1 py-0.5 border rounded w-full dark:bg-gray-800"
+                  />
+                ) : (
+                  row[c.key] as React.ReactNode
+                )}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+EditableTable.displayName = 'EditableTable';

--- a/my-app/src/app/components/tables/ExpandableTable.tsx
+++ b/my-app/src/app/components/tables/ExpandableTable.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { TableProps } from './types';
+
+export interface ExpandableTableProps extends TableProps {
+  renderExpanded: (row: any) => React.ReactNode;
+}
+
+export const ExpandableTable: React.FC<ExpandableTableProps> = ({
+  columns,
+  data,
+  renderExpanded,
+}) => {
+  const [open, setOpen] = useState<Set<number>>(new Set());
+
+  const toggle = (i: number) => {
+    const n = new Set(open);
+    if (n.has(i)) n.delete(i);
+    else n.add(i);
+    setOpen(n);
+  };
+
+  return (
+    <table className="min-w-full text-left" role="table">
+      <thead>
+        <tr>
+          <th />
+          {columns.map((c) => (
+            <th key={c.key} className="px-4 py-2">
+              {c.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, idx) => (
+          <React.Fragment key={idx}>
+            <tr role="row" className="odd:bg-gray-50 dark:odd:bg-gray-800">
+              <td className="px-2 py-2">
+                <button onClick={() => toggle(idx)} aria-expanded={open.has(idx)}>
+                  {open.has(idx) ? '-' : '+'}
+                </button>
+              </td>
+              {columns.map((c) => (
+                <td key={c.key} role="gridcell" className="px-4 py-2">
+                  {row[c.key] as React.ReactNode}
+                </td>
+              ))}
+            </tr>
+            {open.has(idx) && (
+              <tr role="row" className="bg-gray-100 dark:bg-gray-700">
+                <td colSpan={columns.length + 1} className="px-4 py-2">
+                  {renderExpanded(row)}
+                </td>
+              </tr>
+            )}
+          </React.Fragment>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+ExpandableTable.displayName = 'ExpandableTable';

--- a/my-app/src/app/components/tables/ExportableTable.tsx
+++ b/my-app/src/app/components/tables/ExportableTable.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Column, TableProps } from './types';
+import Papa from 'papaparse';
+
+export interface ExportableTableProps extends TableProps {
+  fileName?: string;
+}
+
+export const ExportableTable: React.FC<ExportableTableProps> = ({
+  columns,
+  data,
+  fileName = 'table.csv',
+}) => {
+  const exportCsv = () => {
+    const csv = Papa.unparse(data);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-2">
+      <button className="px-2 py-1 border rounded" onClick={exportCsv}>
+        Export CSV
+      </button>
+      <table className="min-w-full text-left" role="table">
+        <thead>
+          <tr>
+            {columns.map((c) => (
+              <th key={c.key} className="px-4 py-2">
+                {c.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, idx) => (
+            <tr key={idx} role="row" className="odd:bg-gray-50 dark:odd:bg-gray-800">
+              {columns.map((c) => (
+                <td key={c.key} role="gridcell" className="px-4 py-2 whitespace-nowrap">
+                  {row[c.key] as React.ReactNode}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+ExportableTable.displayName = 'ExportableTable';

--- a/my-app/src/app/components/tables/ResponsiveTable.tsx
+++ b/my-app/src/app/components/tables/ResponsiveTable.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { TableProps } from './types';
+
+export interface ResponsiveTableProps extends TableProps {}
+
+export const ResponsiveTable: React.FC<ResponsiveTableProps> = ({ columns, data }) => {
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-full text-left" role="table">
+        <thead>
+          <tr>
+            {columns.map((c, i) => (
+              <th
+                key={c.key}
+                className={`px-4 py-2 ${i > 1 ? 'hidden md:table-cell' : ''}`}
+              >
+                {c.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, idx) => (
+            <tr key={idx} role="row" className="odd:bg-gray-50 dark:odd:bg-gray-800">
+              {columns.map((c, i) => (
+                <td
+                  key={c.key}
+                  role="gridcell"
+                  className={`px-4 py-2 whitespace-nowrap ${i > 1 ? 'hidden md:table-cell' : ''}`}
+                >
+                  {row[c.key] as React.ReactNode}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+ResponsiveTable.displayName = 'ResponsiveTable';

--- a/my-app/src/app/components/tables/SortableDraggableTable.tsx
+++ b/my-app/src/app/components/tables/SortableDraggableTable.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { TableProps } from './types';
+
+export interface SortableDraggableTableProps extends TableProps {}
+
+export const SortableDraggableTable: React.FC<SortableDraggableTableProps> = ({
+  columns,
+  data,
+  onSortChange,
+}) => {
+  const [rows, setRows] = useState(() => data);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const handleDragStart = (index: number) => () => {
+    setDragIndex(index);
+  };
+
+  const handleDrop = (index: number) => () => {
+    if (dragIndex === null || dragIndex === index) return;
+    const newRows = [...rows];
+    const [moved] = newRows.splice(dragIndex, 1);
+    newRows.splice(index, 0, moved);
+    setRows(newRows);
+    onSortChange?.(newRows);
+    setDragIndex(null);
+  };
+
+  return (
+    <table className="min-w-full text-left" role="table">
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c.key} className="px-4 py-2">
+              {c.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, idx) => (
+          <tr
+            key={idx}
+            draggable
+            onDragStart={handleDragStart(idx)}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={handleDrop(idx)}
+            className="odd:bg-gray-50 dark:odd:bg-gray-800"
+            role="row"
+          >
+            {columns.map((c) => (
+              <td key={c.key} role="gridcell" className="px-4 py-2 whitespace-nowrap">
+                {row[c.key] as React.ReactNode}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+SortableDraggableTable.displayName = 'SortableDraggableTable';

--- a/my-app/src/app/components/tables/Table.tsx
+++ b/my-app/src/app/components/tables/Table.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { Column, TableProps } from './types';
+
+export interface BasicTableProps extends TableProps {}
+
+export const Table: React.FC<BasicTableProps> = ({
+  columns,
+  data,
+  sortable = false,
+  onRowClick,
+  className = '',
+}) => {
+  const [sortKey, setSortKey] = useState<string>();
+  const [asc, setAsc] = useState(true);
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const sorted = React.useMemo(() => {
+    if (!sortable || !sortKey) return data;
+    return [...data].sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      if (av > bv) return asc ? 1 : -1;
+      if (av < bv) return asc ? -1 : 1;
+      return 0;
+    });
+  }, [data, sortKey, asc, sortable]);
+
+  const handleHeader = (key: string, isSortable?: boolean) => {
+    if (!sortable || !isSortable) return;
+    if (sortKey === key) setAsc(!asc);
+    else {
+      setSortKey(key);
+      setAsc(true);
+    }
+  };
+
+  const selectRow = (idx: number, row: any) => {
+    setSelected(idx);
+    onRowClick?.(row);
+  };
+
+  return (
+    <table className={`min-w-full text-left ${className}`} role="table">
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th
+              key={c.key}
+              onClick={() => handleHeader(c.key, c.sortable)}
+              className={c.sortable && sortable ? 'cursor-pointer select-none px-4 py-2' : 'px-4 py-2'}
+              aria-sort={sortKey === c.key ? (asc ? 'ascending' : 'descending') : 'none'}
+            >
+              <span className="flex items-center">
+                {c.title}
+                {sortable && c.sortable && sortKey === c.key && (
+                  <span className="ml-1">{asc ? '▲' : '▼'}</span>
+                )}
+              </span>
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((row, idx) => (
+          <tr
+            key={idx}
+            onClick={() => selectRow(idx, row)}
+            className={`hover:bg-gray-100 dark:hover:bg-gray-700 ${selected === idx ? 'bg-gray-200 dark:bg-gray-800' : ''}`}
+            role="row"
+          >
+            {columns.map((c) => (
+              <td key={c.key} role="gridcell" className="px-4 py-2 whitespace-nowrap">
+                {row[c.key] as React.ReactNode}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+Table.displayName = 'Table';

--- a/my-app/src/app/components/tables/TreeTable.tsx
+++ b/my-app/src/app/components/tables/TreeTable.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { TableProps } from './types';
+
+export interface TreeNode {
+  id: string;
+  [key: string]: any;
+  children?: TreeNode[];
+}
+
+export interface TreeTableProps extends TableProps {
+  data: TreeNode[];
+}
+
+export const TreeTable: React.FC<TreeTableProps> = ({ columns, data }) => {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+
+  const toggle = (id: string) => {
+    setOpen((o) => ({ ...o, [id]: !o[id] }));
+  };
+
+  const renderRows = (nodes: TreeNode[], depth = 0) =>
+    nodes.map((node) => (
+      <React.Fragment key={node.id}>
+        <tr role="row" className="odd:bg-gray-50 dark:odd:bg-gray-800">
+          {columns.map((c, idx) => (
+            <td key={c.key} role="gridcell" className="px-4 py-2">
+              {idx === 0 && node.children && (
+                <button
+                  className="mr-1"
+                  onClick={() => toggle(node.id)}
+                  aria-expanded={open[node.id]}
+                >
+                  {open[node.id] ? '-' : '+'}
+                </button>
+              )}
+              <span style={{ paddingLeft: idx === 0 ? depth * 16 : 0 }}>{node[c.key] as React.ReactNode}</span>
+            </td>
+          ))}
+        </tr>
+        {node.children && open[node.id] && renderRows(node.children, depth + 1)}
+      </React.Fragment>
+    ));
+
+  return (
+    <table className="min-w-full text-left" role="table">
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c.key} className="px-4 py-2">
+              {c.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>{renderRows(data)}</tbody>
+    </table>
+  );
+};
+
+TreeTable.displayName = 'TreeTable';

--- a/my-app/src/app/components/tables/VirtualizedTable.tsx
+++ b/my-app/src/app/components/tables/VirtualizedTable.tsx
@@ -1,0 +1,70 @@
+import React, { useState, UIEvent } from 'react';
+import { TableProps } from './types';
+
+export interface VirtualizedTableProps extends TableProps {
+  rowHeight?: number;
+  height?: number;
+}
+
+export const VirtualizedTable: React.FC<VirtualizedTableProps> = ({
+  columns,
+  data,
+  rowHeight = 40,
+  height = 300,
+  onRowClick,
+}) => {
+  const [scrollTop, setScrollTop] = useState(0);
+  const overscan = 5;
+
+  const handleScroll = (e: UIEvent<HTMLTableSectionElement>) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  };
+
+  const start = Math.max(0, Math.floor(scrollTop / rowHeight) - overscan);
+  const end = Math.min(data.length, Math.ceil((scrollTop + height) / rowHeight) + overscan);
+  const totalHeight = data.length * rowHeight;
+
+  return (
+    <div className="overflow-auto" style={{ maxHeight: height + 50 }}>
+      <table className="min-w-full text-left" role="table">
+        <thead>
+          <tr>
+            {columns.map((c) => (
+              <th key={c.key} className="px-4 py-2">
+                {c.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody
+          onScroll={handleScroll}
+          style={{ display: 'block', height, overflowY: 'auto', position: 'relative' }}
+        >
+          <tr style={{ height: totalHeight }} aria-hidden />
+          {data.slice(start, end).map((row, idx) => (
+            <tr
+              key={start + idx}
+              onClick={() => onRowClick?.(row)}
+              style={{
+                position: 'absolute',
+                top: (start + idx) * rowHeight,
+                display: 'table',
+                width: '100%',
+              }}
+              className="odd:bg-gray-50 dark:odd:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
+              role="row"
+            >
+              {columns.map((c) => (
+                <td key={c.key} className="px-4 py-2 whitespace-nowrap" role="gridcell">
+                  {row[c.key] as React.ReactNode}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+VirtualizedTable.displayName = 'VirtualizedTable';

--- a/my-app/src/app/components/tables/__tests__/ComparisonTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ComparisonTable.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { ComparisonTable } from '../ComparisonTable';
+
+const rows = [
+  { id: 1, name: 'A' },
+  { id: 2, name: 'B' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+describe('ComparisonTable', () => {
+  it('highlights differences', () => {
+    const { container } = render(
+      <ComparisonTable data={rows} columns={columns} />,
+    );
+    const cells = container.querySelectorAll('tbody tr:nth-child(2) td');
+    expect(cells[0].className).toMatch(/bg-yellow/);
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/DataGrid.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/DataGrid.test.tsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import { DataGrid } from '../DataGrid';
+
+const rows = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+const columns = [{ key: 'name', title: 'Name', sortable: true }];
+
+describe('DataGrid', () => {
+  it('filters rows', () => {
+    const { getByPlaceholderText, queryByText } = render(
+      <DataGrid data={rows} columns={columns} filterable />,
+    );
+    fireEvent.change(getByPlaceholderText('Filter...'), { target: { value: 'Bob' } });
+    expect(queryByText('Alice')).toBeNull();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/EditableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/EditableTable.test.tsx
@@ -1,0 +1,21 @@
+import { render, fireEvent } from '@testing-library/react';
+import { EditableTable } from '../EditableTable';
+
+const rows = [
+  { id: 1, name: 'A' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+describe('EditableTable', () => {
+  it('saves edited value', () => {
+    const handle = jest.fn();
+    const { getByText, getByDisplayValue } = render(
+      <EditableTable data={rows} columns={columns} onEditSave={handle} />,
+    );
+    fireEvent.doubleClick(getByText('A'));
+    const input = getByDisplayValue('A');
+    fireEvent.change(input, { target: { value: 'B' } });
+    fireEvent.blur(input);
+    expect(handle).toHaveBeenCalledWith([{ id: 1, name: 'B' }]);
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/ExpandableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ExpandableTable.test.tsx
@@ -1,0 +1,22 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ExpandableTable } from '../ExpandableTable';
+
+const rows = [
+  { id: 1, name: 'A' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+describe('ExpandableTable', () => {
+  it('expands row', () => {
+    const { getByRole, getByText, queryByText } = render(
+      <ExpandableTable
+        data={rows}
+        columns={columns}
+        renderExpanded={() => <div>More</div>}
+      />,
+    );
+    expect(queryByText('More')).toBeNull();
+    fireEvent.click(getByRole('button'));
+    expect(getByText('More')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/ExportableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ExportableTable.test.tsx
@@ -1,0 +1,16 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ExportableTable } from '../ExportableTable';
+
+const rows = [{ id: 1, name: 'A' }];
+const columns = [{ key: 'name', title: 'Name' }];
+
+describe('ExportableTable', () => {
+  it('triggers download', () => {
+    const create = jest.spyOn(document, 'createElement');
+    const { getByText } = render(
+      <ExportableTable data={rows} columns={columns} />,
+    );
+    fireEvent.click(getByText('Export CSV'));
+    expect(create).toHaveBeenCalledWith('a');
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/ResponsiveTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ResponsiveTable.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { ResponsiveTable } from '../ResponsiveTable';
+
+const rows = [{ id: 1, name: 'A', age: 20 }];
+const columns = [
+  { key: 'name', title: 'Name' },
+  { key: 'age', title: 'Age' },
+];
+
+describe('ResponsiveTable', () => {
+  it('renders table', () => {
+    const { getByText } = render(
+      <ResponsiveTable data={rows} columns={columns} />,
+    );
+    expect(getByText('Age')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/SortableDraggableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/SortableDraggableTable.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import { SortableDraggableTable } from '../SortableDraggableTable';
+
+const rows = [
+  { id: 1, name: 'A' },
+  { id: 2, name: 'B' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+describe('SortableDraggableTable', () => {
+  it('calls onSortChange', () => {
+    const handle = jest.fn();
+    const { container } = render(
+      <SortableDraggableTable data={rows} columns={columns} onSortChange={handle} />,
+    );
+    const row = container.querySelectorAll('tbody tr')[0];
+    row?.dispatchEvent(new DragEvent('dragstart', { bubbles: true }));
+    const dropRow = container.querySelectorAll('tbody tr')[1];
+    dropRow?.dispatchEvent(new DragEvent('drop', { bubbles: true }));
+    expect(handle).toHaveBeenCalled();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/Table.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/Table.test.tsx
@@ -1,0 +1,19 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Table } from '../Table';
+
+const rows = [
+  { id: 1, name: 'B' },
+  { id: 2, name: 'A' },
+];
+const columns = [{ key: 'name', title: 'Name', sortable: true }];
+
+describe('Table', () => {
+  it('sorts rows when header clicked', () => {
+    const { getAllByRole, getByText } = render(
+      <Table data={rows} columns={columns} sortable />,
+    );
+    fireEvent.click(getByText('Name'));
+    const cells = getAllByRole('gridcell');
+    expect(cells[0]).toHaveTextContent('A');
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/TreeTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/TreeTable.test.tsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import { TreeTable, TreeNode } from '../TreeTable';
+
+const rows: TreeNode[] = [
+  { id: '1', name: 'Parent', children: [{ id: '2', name: 'Child' }] },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+describe('TreeTable', () => {
+  it('toggles children', () => {
+    const { getByText, queryByText } = render(
+      <TreeTable data={rows} columns={columns} />,
+    );
+    expect(queryByText('Child')).toBeNull();
+    fireEvent.click(getByText('+'));
+    expect(getByText('Child')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/VirtualizedTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/VirtualizedTable.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { VirtualizedTable } from '../VirtualizedTable';
+
+const rows = Array.from({ length: 50 }, (_, i) => ({ id: i, name: `Row ${i}` }));
+const columns = [{ key: 'name', title: 'Name' }];
+
+describe('VirtualizedTable', () => {
+  it('renders limited rows', () => {
+    const { container } = render(
+      <VirtualizedTable data={rows} columns={columns} height={100} rowHeight={20} />,
+    );
+    const trs = container.querySelectorAll('tbody tr');
+    expect(trs.length).toBeLessThan(rows.length);
+  });
+});

--- a/my-app/src/app/components/tables/index.ts
+++ b/my-app/src/app/components/tables/index.ts
@@ -1,1 +1,11 @@
-
+export * from './types';
+export * from './Table';
+export * from './DataGrid';
+export * from './EditableTable';
+export * from './ExpandableTable';
+export * from './VirtualizedTable';
+export * from './ResponsiveTable';
+export * from './TreeTable';
+export * from './ComparisonTable';
+export * from './ExportableTable';
+export * from './SortableDraggableTable';

--- a/my-app/src/app/components/tables/stories/ComparisonTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ComparisonTable.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComparisonTable } from '../ComparisonTable';
+
+const rows = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+const meta: Meta<typeof ComparisonTable> = {
+  title: 'tables/ComparisonTable',
+  component: ComparisonTable,
+  args: { data: rows, columns },
+};
+export default meta;
+
+export const Default: StoryObj<typeof ComparisonTable> = {};

--- a/my-app/src/app/components/tables/stories/DataGrid.stories.tsx
+++ b/my-app/src/app/components/tables/stories/DataGrid.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DataGrid } from '../DataGrid';
+
+const rows = [
+  { id: 1, name: 'Alice', age: 30 },
+  { id: 2, name: 'Bob', age: 24 },
+  { id: 3, name: 'Charlie', age: 29 },
+];
+const columns = [
+  { key: 'name', title: 'Name', sortable: true },
+  { key: 'age', title: 'Age', sortable: true },
+];
+
+const meta: Meta<typeof DataGrid> = {
+  title: 'tables/DataGrid',
+  component: DataGrid,
+  args: {
+    data: rows,
+    columns,
+    sortable: true,
+    filterable: true,
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof DataGrid> = {};

--- a/my-app/src/app/components/tables/stories/EditableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/EditableTable.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EditableTable } from '../EditableTable';
+
+const rows = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+const meta: Meta<typeof EditableTable> = {
+  title: 'tables/EditableTable',
+  component: EditableTable,
+  args: { data: rows, columns },
+};
+export default meta;
+
+export const Default: StoryObj<typeof EditableTable> = {};

--- a/my-app/src/app/components/tables/stories/ExpandableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ExpandableTable.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ExpandableTable } from '../ExpandableTable';
+
+const rows = [
+  { id: 1, name: 'Alice', info: 'Developer' },
+  { id: 2, name: 'Bob', info: 'Designer' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+const meta: Meta<typeof ExpandableTable> = {
+  title: 'tables/ExpandableTable',
+  component: ExpandableTable,
+  args: {
+    data: rows,
+    columns,
+    renderExpanded: (row) => <div>{row.info}</div>,
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof ExpandableTable> = {};

--- a/my-app/src/app/components/tables/stories/ExportableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ExportableTable.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ExportableTable } from '../ExportableTable';
+
+const rows = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+const meta: Meta<typeof ExportableTable> = {
+  title: 'tables/ExportableTable',
+  component: ExportableTable,
+  args: { data: rows, columns },
+};
+export default meta;
+
+export const Default: StoryObj<typeof ExportableTable> = {};

--- a/my-app/src/app/components/tables/stories/ResponsiveTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ResponsiveTable.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ResponsiveTable } from '../ResponsiveTable';
+
+const rows = [
+  { id: 1, name: 'Alice', age: 30, role: 'Dev' },
+  { id: 2, name: 'Bob', age: 24, role: 'Design' },
+];
+const columns = [
+  { key: 'name', title: 'Name' },
+  { key: 'age', title: 'Age' },
+  { key: 'role', title: 'Role' },
+];
+
+const meta: Meta<typeof ResponsiveTable> = {
+  title: 'tables/ResponsiveTable',
+  component: ResponsiveTable,
+  args: { data: rows, columns },
+};
+export default meta;
+
+export const Default: StoryObj<typeof ResponsiveTable> = {};

--- a/my-app/src/app/components/tables/stories/SortableDraggableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/SortableDraggableTable.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SortableDraggableTable } from '../SortableDraggableTable';
+
+const rows = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+  { id: 3, name: 'Charlie' },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+const meta: Meta<typeof SortableDraggableTable> = {
+  title: 'tables/SortableDraggableTable',
+  component: SortableDraggableTable,
+  args: { data: rows, columns },
+};
+export default meta;
+
+export const Default: StoryObj<typeof SortableDraggableTable> = {};

--- a/my-app/src/app/components/tables/stories/Table.stories.tsx
+++ b/my-app/src/app/components/tables/stories/Table.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Table } from '../Table';
+
+const rows = [
+  { id: 1, name: 'Alice', age: 30 },
+  { id: 2, name: 'Bob', age: 24 },
+  { id: 3, name: 'Charlie', age: 29 },
+];
+const columns = [
+  { key: 'name', title: 'Name', sortable: true },
+  { key: 'age', title: 'Age', sortable: true },
+];
+
+const meta: Meta<typeof Table> = {
+  title: 'tables/Table',
+  component: Table,
+  args: {
+    data: rows,
+    columns,
+    sortable: true,
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof Table> = {};

--- a/my-app/src/app/components/tables/stories/TreeTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/TreeTable.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TreeTable, TreeNode } from '../TreeTable';
+
+const rows: TreeNode[] = [
+  {
+    id: '1',
+    name: 'Parent',
+    children: [
+      { id: '2', name: 'Child 1' },
+      { id: '3', name: 'Child 2' },
+    ],
+  },
+];
+const columns = [{ key: 'name', title: 'Name' }];
+
+const meta: Meta<typeof TreeTable> = {
+  title: 'tables/TreeTable',
+  component: TreeTable,
+  args: { data: rows, columns },
+};
+export default meta;
+
+export const Default: StoryObj<typeof TreeTable> = {};

--- a/my-app/src/app/components/tables/stories/VirtualizedTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/VirtualizedTable.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { VirtualizedTable } from '../VirtualizedTable';
+
+const rows = Array.from({ length: 100 }, (_, i) => ({ id: i, name: `Row ${i}` }));
+const columns = [{ key: 'name', title: 'Name' }];
+
+const meta: Meta<typeof VirtualizedTable> = {
+  title: 'tables/VirtualizedTable',
+  component: VirtualizedTable,
+  args: {
+    data: rows,
+    columns,
+    height: 200,
+    rowHeight: 30,
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof VirtualizedTable> = {};

--- a/my-app/src/app/components/tables/types.ts
+++ b/my-app/src/app/components/tables/types.ts
@@ -1,0 +1,20 @@
+export interface Column {
+  key: string;
+  title: string;
+  sortable?: boolean;
+}
+
+export interface TableProps {
+  columns: Column[];
+  data: any[];
+  sortable?: boolean;
+  filterable?: boolean;
+  editable?: boolean;
+  expandable?: boolean;
+  virtualized?: boolean;
+  responsive?: boolean;
+  exportable?: boolean;
+  onRowClick?: (rowData: any) => void;
+  onEditSave?: (newData: any) => void;
+  onSortChange?: (newOrder: any[]) => void;
+}


### PR DESCRIPTION
## Summary
- implement professional table components in `src/app/components/tables`
- add re-exports in `index.ts`
- provide tests for each table component
- add Storybook stories for usage examples

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aaff2a23083219a1cb06e75b46dab