### PR TITLE
Add comprehensive table components

### DIFF
--- a/my-app/src/app/components/tables/ComparisonTable.tsx
+++ b/my-app/src/app/components/tables/ComparisonTable.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export interface ComparisonRow {
+  key: string;
+  label: string;
+  a: any;
+  b: any;
+}
+
+export interface ComparisonTableProps {
+  rows: ComparisonRow[];
+}
+
+/**
+ * Highlight differences between two sets of values.
+ */
+export const ComparisonTable: React.FC<ComparisonTableProps> = ({ rows }) => {
+  return (
+    <table className="min-w-full divide-y divide-gray-200" role="table">
+      <thead className="bg-gray-50 dark:bg-gray-800">
+        <tr>
+          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Field</th>
+          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">A</th>
+          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">B</th>
+        </tr>
+      </thead>
+      <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+        {rows.map(r => (
+          <tr key={r.key} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+            <td className="px-4 py-2 font-medium">{r.label}</td>
+            <td className={`px-4 py-2 ${r.a !== r.b ? 'bg-red-50 dark:bg-red-900' : ''}`}>{r.a}</td>
+            <td className={`px-4 py-2 ${r.a !== r.b ? 'bg-green-50 dark:bg-green-900' : ''}`}>{r.b}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/my-app/src/app/components/tables/DataGrid.tsx
+++ b/my-app/src/app/components/tables/DataGrid.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Column } from './Table';
+
+export interface DataGridProps {
+  columns: Column[];
+  data: any[];
+  pageSize?: number;
+}
+
+/**
+ * Advanced table with filtering, sorting and pagination.
+ */
+export const DataGrid: React.FC<DataGridProps> = ({ columns, data, pageSize = 10 }) => {
+  const [filter, setFilter] = useState('');
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortAsc, setSortAsc] = useState(true);
+  const [page, setPage] = useState(0);
+
+  const filtered = React.useMemo(() => {
+    return data.filter(row =>
+      Object.values(row).some(val => String(val).toLowerCase().includes(filter.toLowerCase()))
+    );
+  }, [data, filter]);
+
+  const sorted = React.useMemo(() => {
+    if (!sortKey) return filtered;
+    return [...filtered].sort((a, b) => {
+      if (a[sortKey!] < b[sortKey!]) return sortAsc ? -1 : 1;
+      if (a[sortKey!] > b[sortKey!]) return sortAsc ? 1 : -1;
+      return 0;
+    });
+  }, [filtered, sortKey, sortAsc]);
+
+  const pages = Math.ceil(sorted.length / pageSize);
+  const paged = sorted.slice(page * pageSize, (page + 1) * pageSize);
+
+  const onSort = (key: string) => {
+    if (sortKey === key) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortKey(key);
+      setSortAsc(true);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <input
+        aria-label="Filter rows"
+        value={filter}
+        onChange={e => setFilter(e.target.value)}
+        className="border px-2 py-1 rounded w-full dark:bg-gray-800 dark:text-gray-100"
+        placeholder="Filter..."
+      />
+      <table className="min-w-full divide-y divide-gray-200" role="table">
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            {columns.map(col => (
+              <th
+                key={col.key}
+                onClick={() => col.sortable && onSort(col.key)}
+                aria-sort={sortKey === col.key ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 cursor-pointer select-none"
+              >
+                {col.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+          <AnimatePresence>
+            {paged.map((row, idx) => (
+              <motion.tr key={idx} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                {columns.map(col => (
+                  <td key={col.key} className="px-4 py-2 whitespace-nowrap">
+                    {row[col.key]}
+                  </td>
+                ))}
+              </motion.tr>
+            ))}
+          </AnimatePresence>
+        </tbody>
+      </table>
+      <div className="flex justify-between items-center">
+        <button disabled={page === 0} onClick={() => setPage(p => Math.max(p - 1, 0))} className="px-2 py-1 border rounded disabled:opacity-50">
+          Prev
+        </button>
+        <span>
+          Page {page + 1} of {pages}
+        </span>
+        <button disabled={page + 1 >= pages} onClick={() => setPage(p => Math.min(p + 1, pages - 1))} className="px-2 py-1 border rounded disabled:opacity-50">
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/my-app/src/app/components/tables/EditableTable.tsx
+++ b/my-app/src/app/components/tables/EditableTable.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Column } from './Table';
+
+export interface EditableTableProps {
+  columns: Column[];
+  data: any[];
+  onEditSave?: (data: any[]) => void;
+}
+
+/**
+ * Inline editable data table.
+ */
+export const EditableTable: React.FC<EditableTableProps> = ({ columns, data, onEditSave }) => {
+  const [rows, setRows] = useState(() => data.map(row => ({ ...row })));
+  const [editing, setEditing] = useState<{ row: number; key: string } | null>(null);
+
+  const save = () => onEditSave?.(rows);
+
+  const startEdit = (row: number, key: string) => setEditing({ row, key });
+
+  const stopEdit = () => setEditing(null);
+
+  const update = (row: number, key: string, value: string) => {
+    setRows(r => r.map((item, idx) => (idx === row ? { ...item, [key]: value } : item)));
+  };
+
+  return (
+    <div className="space-y-2">
+      <table className="min-w-full divide-y divide-gray-200" role="table">
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            {columns.map(col => (
+              <th key={col.key} className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">
+                {col.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+              {columns.map(col => (
+                <td key={col.key} className="px-4 py-2" onDoubleClick={() => startEdit(rowIndex, col.key)}>
+                  {editing && editing.row === rowIndex && editing.key === col.key ? (
+                    <input
+                      autoFocus
+                      value={row[col.key]}
+                      onChange={e => update(rowIndex, col.key, e.target.value)}
+                      onBlur={stopEdit}
+                      className="border px-1 rounded w-full dark:bg-gray-800 dark:text-gray-100"
+                    />
+                  ) : (
+                    row[col.key]
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button onClick={save} className="px-3 py-1 border rounded">Save</button>
+    </div>
+  );
+};

--- a/my-app/src/app/components/tables/ExpandableTable.tsx
+++ b/my-app/src/app/components/tables/ExpandableTable.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Column } from './Table';
+
+export interface ExpandableTableProps {
+  columns: Column[];
+  data: any[];
+  renderExpanded: (row: any) => React.ReactNode;
+}
+
+/**
+ * Table with expandable rows for extra details.
+ */
+export const ExpandableTable: React.FC<ExpandableTableProps> = ({ columns, data, renderExpanded }) => {
+  const [open, setOpen] = useState<Set<number>>(new Set());
+
+  const toggle = (idx: number) => {
+    setOpen(p => {
+      const set = new Set(p);
+      set.has(idx) ? set.delete(idx) : set.add(idx);
+      return set;
+    });
+  };
+
+  return (
+    <table className="min-w-full divide-y divide-gray-200" role="table">
+      <thead className="bg-gray-50 dark:bg-gray-800">
+        <tr>
+          {columns.map(col => (
+            <th key={col.key} className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">
+              {col.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+        {data.map((row, idx) => (
+          <React.Fragment key={idx}>
+            <tr onClick={() => toggle(idx)} className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
+              {columns.map(col => (
+                <td key={col.key} className="px-4 py-2 whitespace-nowrap">
+                  {row[col.key]}
+                </td>
+              ))}
+            </tr>
+            <AnimatePresence>
+              {open.has(idx) && (
+                <motion.tr initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                  <td colSpan={columns.length} className="px-4 py-2 bg-gray-50 dark:bg-gray-800">
+                    {renderExpanded(row)}
+                  </td>
+                </motion.tr>
+              )}
+            </AnimatePresence>
+          </React.Fragment>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/my-app/src/app/components/tables/ExportableTable.tsx
+++ b/my-app/src/app/components/tables/ExportableTable.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Papa from 'papaparse';
+import { Column } from './Table';
+
+export interface ExportableTableProps {
+  columns: Column[];
+  data: any[];
+}
+
+/**
+ * Table with CSV export capability.
+ */
+export const ExportableTable: React.FC<ExportableTableProps> = ({ columns, data }) => {
+  const exportCsv = () => {
+    const csv = Papa.unparse(data);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'data.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-2">
+      <button onClick={exportCsv} className="px-3 py-1 border rounded">Export CSV</button>
+      <table className="min-w-full divide-y divide-gray-200" role="table">
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            {columns.map(col => (
+              <th key={col.key} className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">
+                {col.title}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+          {data.map((row, idx) => (
+            <tr key={idx} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+              {columns.map(col => (
+                <td key={col.key} className="px-4 py-2 whitespace-nowrap">
+                  {row[col.key]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/my-app/src/app/components/tables/ResponsiveTable.tsx
+++ b/my-app/src/app/components/tables/ResponsiveTable.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Column } from './Table';
+
+export interface ResponsiveTableProps {
+  columns: (Column & { hidden?: boolean; hiddenSm?: boolean })[];
+  data: any[];
+}
+
+/**
+ * Table with responsive columns.
+ */
+export const ResponsiveTable: React.FC<ResponsiveTableProps> = ({ columns, data }) => {
+  return (
+    <table className="min-w-full divide-y divide-gray-200" role="table">
+      <thead className="bg-gray-50 dark:bg-gray-800">
+        <tr>
+          {columns.map(col => (
+            <th
+              key={col.key}
+              className={`${col.hidden ? 'hidden' : ''} ${col.hiddenSm ? 'sm:hidden' : ''} px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300`}
+            >
+              {col.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+        {data.map((row, idx) => (
+          <tr key={idx} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+            {columns.map(col => (
+              <td key={col.key} className={`${col.hidden ? 'hidden' : ''} ${col.hiddenSm ? 'sm:hidden' : ''} px-4 py-2`}>
+                {row[col.key]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/my-app/src/app/components/tables/SortableDraggableTable.tsx
+++ b/my-app/src/app/components/tables/SortableDraggableTable.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { Column } from './Table';
+
+export interface SortableDraggableTableProps {
+  columns: Column[];
+  data: any[];
+  onSortChange?: (data: any[]) => void;
+}
+
+/**
+ * Drag-and-drop row reordering table.
+ */
+export const SortableDraggableTable: React.FC<SortableDraggableTableProps> = ({ columns, data, onSortChange }) => {
+  const [rows, setRows] = React.useState(() => data.map(r => ({ ...r })));
+
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    const newRows = Array.from(rows);
+    const [moved] = newRows.splice(result.source.index, 1);
+    newRows.splice(result.destination.index, 0, moved);
+    setRows(newRows);
+    onSortChange?.(newRows);
+  };
+
+  return (
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Droppable droppableId="table">
+        {provided => (
+          <table ref={provided.innerRef} {...provided.droppableProps} className="min-w-full divide-y divide-gray-200" role="table">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                {columns.map(col => (
+                  <th key={col.key} className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">
+                    {col.title}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+              {rows.map((row, idx) => (
+                <Draggable key={idx} draggableId={String(idx)} index={idx}>
+                  {prov => (
+                    <tr ref={prov.innerRef} {...prov.draggableProps} {...prov.dragHandleProps} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                      {columns.map(col => (
+                        <td key={col.key} className="px-4 py-2 whitespace-nowrap">
+                          {row[col.key]}
+                        </td>
+                      ))}
+                    </tr>
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </tbody>
+          </table>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+};

--- a/my-app/src/app/components/tables/Table.tsx
+++ b/my-app/src/app/components/tables/Table.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+
+export interface Column {
+  key: string;
+  title: string;
+  sortable?: boolean;
+}
+
+export interface TableProps {
+  columns: Column[];
+  data: any[];
+  sortable?: boolean;
+  onRowClick?: (row: any) => void;
+}
+
+/**
+ * Basic table with sortable columns and selectable rows.
+ */
+export const Table: React.FC<TableProps> = ({ columns, data, sortable = true, onRowClick }) => {
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortAsc, setSortAsc] = useState(true);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  const sortedData = React.useMemo(() => {
+    if (!sortKey) return data;
+    return [...data].sort((a, b) => {
+      if (a[sortKey!] < b[sortKey!]) return sortAsc ? -1 : 1;
+      if (a[sortKey!] > b[sortKey!]) return sortAsc ? 1 : -1;
+      return 0;
+    });
+  }, [data, sortKey, sortAsc]);
+
+  const onSort = (key: string) => {
+    if (!sortable) return;
+    if (sortKey === key) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortKey(key);
+      setSortAsc(true);
+    }
+  };
+
+  const toggleRow = (idx: number, row: any) => {
+    setSelected(prev => {
+      const set = new Set(prev);
+      set.has(idx) ? set.delete(idx) : set.add(idx);
+      return set;
+    });
+    onRowClick?.(row);
+  };
+
+  return (
+    <table className="min-w-full divide-y divide-gray-200" role="table">
+      <thead className="bg-gray-50 dark:bg-gray-800">
+        <tr>
+          {columns.map(col => (
+            <th
+              key={col.key}
+              onClick={() => col.sortable && onSort(col.key)}
+              aria-sort={sortKey === col.key ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 cursor-pointer select-none"
+            >
+              {col.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+        {sortedData.map((row, idx) => (
+          <tr
+            key={idx}
+            onClick={() => toggleRow(idx, row)}
+            className={`cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 ${selected.has(idx) ? 'bg-blue-100 dark:bg-blue-900' : ''}`}
+          >
+            {columns.map(col => (
+              <td key={col.key} className="px-4 py-2 whitespace-nowrap">
+                {row[col.key]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/my-app/src/app/components/tables/TreeTable.tsx
+++ b/my-app/src/app/components/tables/TreeTable.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Column } from './Table';
+
+export interface TreeNode {
+  id: string;
+  parentId?: string;
+  data: any;
+}
+
+export interface TreeTableProps {
+  columns: Column[];
+  data: TreeNode[];
+}
+
+/**
+ * Nested expandable tree table.
+ */
+export const TreeTable: React.FC<TreeTableProps> = ({ columns, data }) => {
+  const [open, setOpen] = useState<Set<string>>(new Set());
+
+  const children = (parentId?: string) => data.filter(n => n.parentId === parentId);
+
+  const renderRows = (parentId?: string, depth = 0): React.ReactNode => {
+    return children(parentId).map(node => (
+      <React.Fragment key={node.id}>
+        <tr
+          onClick={() => setOpen(o => new Set(o.has(node.id) ? [...Array.from(o).filter(i => i !== node.id)] : [...o, node.id]))}
+          className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
+        >
+          {columns.map((col, idx) => (
+            <td key={col.key} className="px-4 py-2" style={{ paddingLeft: idx === 0 ? depth * 16 + 16 : undefined }}>
+              {idx === 0 && children(node.id).length > 0 && (
+                <span className="mr-2">{open.has(node.id) ? '-' : '+'}</span>
+              )}
+              {node.data[col.key]}
+            </td>
+          ))}
+        </tr>
+        {open.has(node.id) && renderRows(node.id, depth + 1)}
+      </React.Fragment>
+    ));
+  };
+
+  return (
+    <table className="min-w-full divide-y divide-gray-200" role="table">
+      <thead className="bg-gray-50 dark:bg-gray-800">
+        <tr>
+          {columns.map(col => (
+            <th key={col.key} className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">
+              {col.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200">{renderRows(undefined, 0)}</tbody>
+    </table>
+  );
+};

--- a/my-app/src/app/components/tables/VirtualizedTable.tsx
+++ b/my-app/src/app/components/tables/VirtualizedTable.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
+import { Column } from './Table';
+
+export interface VirtualizedTableProps {
+  columns: Column[];
+  data: any[];
+  height: number;
+  rowHeight?: number;
+}
+
+/**
+ * Virtualized table for large data sets using react-window.
+ */
+export const VirtualizedTable: React.FC<VirtualizedTableProps> = ({ columns, data, height, rowHeight = 35 }) => {
+  const Row = ({ index, style }: ListChildComponentProps) => (
+    <div style={style} className="flex divide-x divide-gray-200">
+      {columns.map(col => (
+        <div key={col.key} className="flex-1 px-2 py-1 whitespace-nowrap overflow-hidden text-ellipsis">
+          {data[index][col.key]}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div role="table" className="border divide-y divide-gray-200">
+      <div className="flex bg-gray-50 dark:bg-gray-800 font-medium text-sm">
+        {columns.map(col => (
+          <div key={col.key} className="flex-1 px-2 py-1">
+            {col.title}
+          </div>
+        ))}
+      </div>
+      <List height={height} itemCount={data.length} itemSize={rowHeight} width="100%">
+        {Row}
+      </List>
+    </div>
+  );
+};

--- a/my-app/src/app/components/tables/__tests__/ComparisonTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ComparisonTable.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { ComparisonTable } from '../ComparisonTable';
+
+const rows = [
+  { key: 'name', label: 'Name', a: 'Alice', b: 'Bob' },
+];
+
+describe('ComparisonTable', () => {
+  it('highlights differences', () => {
+    const { container } = render(<ComparisonTable rows={rows} />);
+    const cells = container.querySelectorAll('tbody td');
+    expect(cells[1].className).toMatch(/bg-red/);
+    expect(cells[2].className).toMatch(/bg-green/);
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/DataGrid.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/DataGrid.test.tsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import { DataGrid } from '../DataGrid';
+
+const columns = [
+  { key: 'name', title: 'Name', sortable: true },
+];
+const data = [
+  { name: 'Alice' },
+  { name: 'Bob' },
+];
+
+describe('DataGrid', () => {
+  it('filters rows', () => {
+    const { getByLabelText, queryByText } = render(<DataGrid columns={columns} data={data} pageSize={10} />);
+    fireEvent.change(getByLabelText('Filter rows'), { target: { value: 'Bob' } });
+    expect(queryByText('Alice')).not.toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/EditableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/EditableTable.test.tsx
@@ -1,0 +1,20 @@
+import { render, fireEvent } from '@testing-library/react';
+import { EditableTable } from '../EditableTable';
+
+const columns = [
+  { key: 'name', title: 'Name' },
+];
+const data = [
+  { name: 'Alice' },
+];
+
+describe('EditableTable', () => {
+  it('edits cell on double click', () => {
+    const { getByText, getByDisplayValue } = render(<EditableTable columns={columns} data={data} />);
+    fireEvent.doubleClick(getByText('Alice'));
+    const input = getByDisplayValue('Alice') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Bob' } });
+    fireEvent.blur(input);
+    expect(getByText('Bob')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/ExpandableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ExpandableTable.test.tsx
@@ -1,0 +1,17 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ExpandableTable } from '../ExpandableTable';
+
+const columns = [
+  { key: 'name', title: 'Name' },
+];
+const data = [
+  { name: 'Alice', info: 'Info' },
+];
+
+describe('ExpandableTable', () => {
+  it('expands row on click', () => {
+    const { getByText } = render(<ExpandableTable columns={columns} data={data} renderExpanded={row => <div>{row.info}</div>} />);
+    fireEvent.click(getByText('Alice'));
+    expect(getByText('Info')).toBeInTheDocument();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/ExportableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ExportableTable.test.tsx
@@ -1,0 +1,15 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ExportableTable } from '../ExportableTable';
+
+const columns = [{ key: 'name', title: 'Name' }];
+const data = [{ name: 'Alice' }];
+
+describe('ExportableTable', () => {
+  it('triggers export', () => {
+    const { getByText } = render(<ExportableTable columns={columns} data={data} />);
+    const spy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('url');
+    fireEvent.click(getByText('Export CSV'));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/ResponsiveTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/ResponsiveTable.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { ResponsiveTable } from '../ResponsiveTable';
+
+const columns = [
+  { key: 'name', title: 'Name' },
+];
+const data = [
+  { name: 'Alice' },
+];
+
+describe('ResponsiveTable', () => {
+  it('renders', () => {
+    render(<ResponsiveTable columns={columns} data={data} />);
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/SortableDraggableTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/SortableDraggableTable.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { SortableDraggableTable } from '../SortableDraggableTable';
+
+const columns = [{ key: 'name', title: 'Name' }];
+const data = [{ name: 'A' }, { name: 'B' }];
+
+describe('SortableDraggableTable', () => {
+  it('renders', () => {
+    render(<SortableDraggableTable columns={columns} data={data} />);
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/Table.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/Table.test.tsx
@@ -1,0 +1,20 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Table } from '../Table';
+
+const columns = [
+  { key: 'name', title: 'Name', sortable: true },
+  { key: 'age', title: 'Age', sortable: true },
+];
+const data = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+];
+
+describe('Table', () => {
+  it('sorts rows when header clicked', () => {
+    const { getByText, container } = render(<Table columns={columns} data={data} />);
+    fireEvent.click(getByText('Age'));
+    const firstRow = container.querySelector('tbody tr:first-child td') as HTMLElement;
+    expect(firstRow.textContent).toBe('Bob');
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/TreeTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/TreeTable.test.tsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import { TreeTable } from '../TreeTable';
+
+const columns = [{ key: 'name', title: 'Name' }];
+const data = [
+  { id: '1', data: { name: 'Root' } },
+  { id: '2', parentId: '1', data: { name: 'Child' } },
+];
+
+describe('TreeTable', () => {
+  it('toggles child rows', () => {
+    const { getByText, queryByText } = render(<TreeTable columns={columns} data={data} />);
+    fireEvent.click(getByText('Root'));
+    expect(getByText('Child')).toBeInTheDocument();
+    fireEvent.click(getByText('Root'));
+    expect(queryByText('Child')).not.toBeVisible();
+  });
+});

--- a/my-app/src/app/components/tables/__tests__/VirtualizedTable.test.tsx
+++ b/my-app/src/app/components/tables/__tests__/VirtualizedTable.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import { VirtualizedTable } from '../VirtualizedTable';
+
+const columns = [
+  { key: 'name', title: 'Name' },
+];
+const data = Array.from({ length: 20 }, (_, i) => ({ name: `Item ${i}` }));
+
+describe('VirtualizedTable', () => {
+  it('renders without crashing', () => {
+    render(<VirtualizedTable columns={columns} data={data} height={100} />);
+  });
+});

--- a/my-app/src/app/components/tables/index.ts
+++ b/my-app/src/app/components/tables/index.ts
@@ -1,1 +1,10 @@
-
+export * from './Table';
+export * from './DataGrid';
+export * from './EditableTable';
+export * from './ExpandableTable';
+export * from './VirtualizedTable';
+export * from './ResponsiveTable';
+export * from './TreeTable';
+export * from './ComparisonTable';
+export * from './ExportableTable';
+export * from './SortableDraggableTable';

--- a/my-app/src/app/components/tables/stories/ComparisonTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ComparisonTable.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComparisonTable } from '../ComparisonTable';
+
+const meta: Meta<typeof ComparisonTable> = {
+  title: 'tables/ComparisonTable',
+  component: ComparisonTable,
+};
+export default meta;
+
+const rows = [
+  { key: 'name', label: 'Name', a: 'Alice', b: 'Alicia' },
+  { key: 'age', label: 'Age', a: 30, b: 30 },
+];
+
+export const Primary: StoryObj<typeof ComparisonTable> = {
+  args: { rows },
+};

--- a/my-app/src/app/components/tables/stories/DataGrid.stories.tsx
+++ b/my-app/src/app/components/tables/stories/DataGrid.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DataGrid } from '../DataGrid';
+
+const meta: Meta<typeof DataGrid> = {
+  title: 'tables/DataGrid',
+  component: DataGrid,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name', sortable: true },
+  { key: 'age', title: 'Age', sortable: true },
+];
+const data = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+  { name: 'Carol', age: 40 },
+];
+
+export const Primary: StoryObj<typeof DataGrid> = {
+  args: { columns, data, pageSize: 2 },
+};

--- a/my-app/src/app/components/tables/stories/EditableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/EditableTable.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EditableTable } from '../EditableTable';
+
+const meta: Meta<typeof EditableTable> = {
+  title: 'tables/EditableTable',
+  component: EditableTable,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name' },
+  { key: 'age', title: 'Age' },
+];
+const data = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+];
+
+export const Primary: StoryObj<typeof EditableTable> = {
+  args: { columns, data },
+};

--- a/my-app/src/app/components/tables/stories/ExpandableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ExpandableTable.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ExpandableTable } from '../ExpandableTable';
+
+const meta: Meta<typeof ExpandableTable> = {
+  title: 'tables/ExpandableTable',
+  component: ExpandableTable,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name' },
+  { key: 'age', title: 'Age' },
+];
+const data = [
+  { name: 'Alice', age: 30, info: 'Extra info about Alice' },
+  { name: 'Bob', age: 25, info: 'More about Bob' },
+];
+
+export const Primary: StoryObj<typeof ExpandableTable> = {
+  args: {
+    columns,
+    data,
+    renderExpanded: (row: any) => <div>{row.info}</div>,
+  },
+};

--- a/my-app/src/app/components/tables/stories/ExportableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ExportableTable.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ExportableTable } from '../ExportableTable';
+
+const meta: Meta<typeof ExportableTable> = {
+  title: 'tables/ExportableTable',
+  component: ExportableTable,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name' },
+  { key: 'age', title: 'Age' },
+];
+const data = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+];
+
+export const Primary: StoryObj<typeof ExportableTable> = {
+  args: { columns, data },
+};

--- a/my-app/src/app/components/tables/stories/ResponsiveTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/ResponsiveTable.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ResponsiveTable } from '../ResponsiveTable';
+
+const meta: Meta<typeof ResponsiveTable> = {
+  title: 'tables/ResponsiveTable',
+  component: ResponsiveTable,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name' },
+  { key: 'age', title: 'Age', hiddenSm: true },
+  { key: 'city', title: 'City' },
+];
+const data = [
+  { name: 'Alice', age: 30, city: 'New York' },
+  { name: 'Bob', age: 25, city: 'London' },
+];
+
+export const Primary: StoryObj<typeof ResponsiveTable> = {
+  args: { columns, data },
+};

--- a/my-app/src/app/components/tables/stories/SortableDraggableTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/SortableDraggableTable.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SortableDraggableTable } from '../SortableDraggableTable';
+
+const meta: Meta<typeof SortableDraggableTable> = {
+  title: 'tables/SortableDraggableTable',
+  component: SortableDraggableTable,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name' },
+];
+const data = [
+  { name: 'Alice' },
+  { name: 'Bob' },
+  { name: 'Carol' },
+];
+
+export const Primary: StoryObj<typeof SortableDraggableTable> = {
+  args: { columns, data },
+};

--- a/my-app/src/app/components/tables/stories/Table.stories.tsx
+++ b/my-app/src/app/components/tables/stories/Table.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Table } from '../Table';
+
+const meta: Meta<typeof Table> = {
+  title: 'tables/Table',
+  component: Table,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name', sortable: true },
+  { key: 'age', title: 'Age', sortable: true },
+];
+const data = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+];
+
+export const Primary: StoryObj<typeof Table> = {
+  args: { columns, data },
+};

--- a/my-app/src/app/components/tables/stories/TreeTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/TreeTable.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TreeTable } from '../TreeTable';
+
+const meta: Meta<typeof TreeTable> = {
+  title: 'tables/TreeTable',
+  component: TreeTable,
+};
+export default meta;
+
+const columns = [
+  { key: 'name', title: 'Name' },
+];
+
+const data = [
+  { id: '1', data: { name: 'Root 1' } },
+  { id: '2', parentId: '1', data: { name: 'Child 1' } },
+  { id: '3', data: { name: 'Root 2' } },
+];
+
+export const Primary: StoryObj<typeof TreeTable> = {
+  args: { columns, data },
+};

--- a/my-app/src/app/components/tables/stories/VirtualizedTable.stories.tsx
+++ b/my-app/src/app/components/tables/stories/VirtualizedTable.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { VirtualizedTable } from '../VirtualizedTable';
+
+const meta: Meta<typeof VirtualizedTable> = {
+  title: 'tables/VirtualizedTable',
+  component: VirtualizedTable,
+};
+export default meta;
+
+const columns = [
+  { key: 'index', title: '#' },
+  { key: 'name', title: 'Name' },
+];
+const data = Array.from({ length: 100 }, (_, i) => ({ index: i + 1, name: `Item ${i + 1}` }));
+
+export const Primary: StoryObj<typeof VirtualizedTable> = {
+  args: { columns, data, height: 200 },
+};


### PR DESCRIPTION
## Summary
- add professional table components with features like sorting, editing, expansion, virtualisation, exporting and drag-and-drop
- create Storybook stories for table components
- add Jest tests for table components

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab0019ea883219f80557871d6628d