### PR TITLE
Implement theme and typography components

### DIFF
--- a/my-app/src/app/components/tests/CodeBlock.test.tsx
+++ b/my-app/src/app/components/tests/CodeBlock.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { CodeBlock } from '@app/components/typography/CodeBlock';
+
+it('renders code element', () => {
+  const { container } = render(<CodeBlock>const a = 1;</CodeBlock>);
+  const code = container.querySelector('code');
+  expect(code).toBeInTheDocument();
+});

--- a/my-app/src/app/components/tests/ColorPicker.test.tsx
+++ b/my-app/src/app/components/tests/ColorPicker.test.tsx
@@ -1,0 +1,11 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ColorPicker } from '@app/components/theme/ColorPicker';
+
+it('updates color on input change', () => {
+  const handle = jest.fn();
+  const { getByLabelText } = render(
+    <ColorPicker value="#ffffff" onChange={handle} />
+  );
+  fireEvent.change(getByLabelText('Color picker'), { target: { value: '#000000' } });
+  expect(handle).toHaveBeenCalledWith('#000000');
+});

--- a/my-app/src/app/components/tests/ColorSwatch.test.tsx
+++ b/my-app/src/app/components/tests/ColorSwatch.test.tsx
@@ -1,0 +1,11 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ColorSwatch } from '@app/components/theme/ColorSwatch';
+
+it('calls onSelect with color value', () => {
+  const handle = jest.fn();
+  const { getByLabelText } = render(
+    <ColorSwatch colors={{ red: '#ff0000' }} onSelect={handle} />
+  );
+  fireEvent.click(getByLabelText('red'));
+  expect(handle).toHaveBeenCalledWith('#ff0000');
+});

--- a/my-app/src/app/components/tests/Heading.test.tsx
+++ b/my-app/src/app/components/tests/Heading.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { Heading } from '@app/components/typography/Heading';
+
+it('renders correct heading level', () => {
+  const { container } = render(<Heading level={3}>Hi</Heading>);
+  const h3 = container.querySelector('h3');
+  expect(h3).toBeInTheDocument();
+});

--- a/my-app/src/app/components/tests/InlineCode.test.tsx
+++ b/my-app/src/app/components/tests/InlineCode.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { InlineCode } from '@app/components/typography/InlineCode';
+
+it('renders inline code', () => {
+  const { container } = render(<InlineCode>a</InlineCode>);
+  const code = container.querySelector('code');
+  expect(code).toBeInTheDocument();
+});

--- a/my-app/src/app/components/tests/Link.test.tsx
+++ b/my-app/src/app/components/tests/Link.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import { Link } from '@app/components/typography/Link';
+
+it('adds target blank when external', () => {
+  const { getByRole } = render(
+    <Link href="https://example.com" external>
+      A
+    </Link>
+  );
+  const a = getByRole('link');
+  expect(a.getAttribute('target')).toBe('_blank');
+});

--- a/my-app/src/app/components/tests/Paragraph.test.tsx
+++ b/my-app/src/app/components/tests/Paragraph.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { Paragraph } from '@app/components/typography/Paragraph';
+
+it('applies leading class', () => {
+  const { getByText } = render(<Paragraph leading="tight">Hello</Paragraph>);
+  const p = getByText('Hello');
+  expect(p.className).toContain('leading-tight');
+});

--- a/my-app/src/app/components/tests/Text.test.tsx
+++ b/my-app/src/app/components/tests/Text.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import { Text } from '@app/components/typography/Text';
+
+it('renders with custom tag', () => {
+  const { container } = render(
+    <Text as="span" className="test" />
+  );
+  const span = container.querySelector('span');
+  expect(span).toBeInTheDocument();
+});

--- a/my-app/src/app/components/tests/ThemeProvider.test.tsx
+++ b/my-app/src/app/components/tests/ThemeProvider.test.tsx
@@ -1,0 +1,23 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider, useTheme } from '@app/components/theme';
+
+const TestComp = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button onClick={toggleTheme} data-theme={theme}>
+      toggle
+    </button>
+  );
+};
+
+test('toggles theme', () => {
+  const { getByText } = render(
+    <ThemeProvider>
+      <TestComp />
+    </ThemeProvider>
+  );
+  const btn = getByText('toggle');
+  expect(btn.getAttribute('data-theme')).toBe('light');
+  fireEvent.click(btn);
+  expect(btn.getAttribute('data-theme')).toBe('dark');
+});

--- a/my-app/src/app/components/tests/ThemeSwitcher.test.tsx
+++ b/my-app/src/app/components/tests/ThemeSwitcher.test.tsx
@@ -1,0 +1,15 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@app/components/theme/ThemeProvider';
+import { ThemeSwitcher } from '@app/components/theme/ThemeSwitcher';
+
+it('switches theme on click', () => {
+  const { getByRole } = render(
+    <ThemeProvider>
+      <ThemeSwitcher />
+    </ThemeProvider>
+  );
+  const btn = getByRole('button');
+  expect(document.documentElement.classList.contains('light')).toBe(true);
+  fireEvent.click(btn);
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+});

--- a/my-app/src/app/components/theme/ColorPicker.stories.tsx
+++ b/my-app/src/app/components/theme/ColorPicker.stories.tsx
@@ -1,10 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 import { ColorPicker } from './ColorPicker';
 
 const meta: Meta<typeof ColorPicker> = {
   title: 'theme/ColorPicker',
   component: ColorPicker,
-  args: { children: 'ColorPicker' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  render: (args) => {
+    const [val, setVal] = useState(args.value);
+    return <ColorPicker value={val} onChange={setVal} />;
+  },
+  args: { value: '#1d4ed8' },
 };
 export default meta;
 export const Default: StoryObj<typeof ColorPicker> = {};

--- a/my-app/src/app/components/theme/ColorPicker.tsx
+++ b/my-app/src/app/components/theme/ColorPicker.tsx
@@ -1,14 +1,35 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
-export interface ColorPickerProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+export interface ColorPickerProps {
+  value: string;
+  onChange: (hex: string) => void;
   className?: string;
 }
 
-/** ColorPicker component */
-export const ColorPicker: React.FC<ColorPickerProps> = ({ className = '', children, ...rest }) => {
+export const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange, className }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value);
+  };
+
   return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
+    <div className={clsx('flex items-center space-x-2', className)}>
+      <motion.input
+        type="color"
+        aria-label="Color picker"
+        role="slider"
+        whileTap={{ scale: 0.95 }}
+        className="h-8 w-8 border rounded"
+        value={value}
+        onChange={handleChange}
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={handleChange}
+        className="border rounded px-2 py-1 text-sm w-24"
+      />
+    </div>
   );
 };

--- a/my-app/src/app/components/theme/ColorSwatch.stories.tsx
+++ b/my-app/src/app/components/theme/ColorSwatch.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ColorSwatch } from './ColorSwatch';
+import { colors } from './theme';
 
 const meta: Meta<typeof ColorSwatch> = {
   title: 'theme/ColorSwatch',
   component: ColorSwatch,
-  args: { children: 'ColorSwatch' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  args: {
+    colors,
+  },
 };
 export default meta;
 export const Default: StoryObj<typeof ColorSwatch> = {};

--- a/my-app/src/app/components/theme/ColorSwatch.tsx
+++ b/my-app/src/app/components/theme/ColorSwatch.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
-export interface ColorSwatchProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+export interface ColorSwatchProps {
+  colors: Record<string, string>;
+  onSelect?: (color: string) => void;
   className?: string;
 }
 
-/** ColorSwatch component */
-export const ColorSwatch: React.FC<ColorSwatchProps> = ({ className = '', children, ...rest }) => {
+export const ColorSwatch: React.FC<ColorSwatchProps> = ({ colors, onSelect, className }) => {
   return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
+    <div role="list" className={clsx('grid grid-cols-6 gap-2', className)}>
+      {Object.entries(colors).map(([name, value]) => (
+        <motion.button
+          key={name}
+          role="listitem"
+          aria-label={name}
+          style={{ backgroundColor: value }}
+          className="h-8 w-8 rounded focus:outline-none focus:ring-2"
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+          onClick={() => onSelect?.(value)}
+        />
+      ))}
+    </div>
   );
 };

--- a/my-app/src/app/components/theme/ThemeProvider.stories.tsx
+++ b/my-app/src/app/components/theme/ThemeProvider.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider } from './ThemeProvider';
+import { ThemeProvider, ThemeProviderProps, ThemeSwitcher } from './';
 
-const meta: Meta<typeof ThemeProvider> = {
+const meta: Meta<ThemeProviderProps> = {
   title: 'theme/ThemeProvider',
   component: ThemeProvider,
-  args: { children: 'ThemeProvider' },
+  parameters: { docs: { description: { component: "Provides theme context" } } },
+  args: {
+    children: (
+      <div className="p-4">
+        <p className="mb-2">Toggle theme using the switcher.</p>
+        <ThemeSwitcher />
+      </div>
+    ),
+  },
 };
 export default meta;
-export const Default: StoryObj<typeof ThemeProvider> = {};
+export const Default: StoryObj<ThemeProviderProps> = {};

--- a/my-app/src/app/components/theme/ThemeProvider.tsx
+++ b/my-app/src/app/components/theme/ThemeProvider.tsx
@@ -1,14 +1,50 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { colors, spacing, radii, shadows, fontSizes } from './theme';
 
-export interface ThemeProviderProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+interface ThemeContextValue {
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export interface ThemeProviderProps {
+  children: React.ReactNode;
   className?: string;
 }
 
-/** ThemeProvider component */
-export const ThemeProvider: React.FC<ThemeProviderProps> = ({ className = '', children, ...rest }) => {
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, className }) => {
+  const [theme, setTheme] = useState<'light' | 'dark'>(
+    (localStorage.getItem('theme') as 'light' | 'dark') || 'light'
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    Object.entries(colors).forEach(([k, v]) => root.style.setProperty(`--color-${k}`, v));
+    Object.entries(spacing).forEach(([k, v]) => root.style.setProperty(`--spacing-${k}`, v));
+    Object.entries(radii).forEach(([k, v]) => root.style.setProperty(`--radius-${k}`, v));
+    Object.entries(shadows).forEach(([k, v]) => root.style.setProperty(`--shadow-${k}`, v));
+    Object.entries(fontSizes).forEach(([k, v]) => root.style.setProperty(`--font-size-${k}`, v));
+  }, []);
+
+  const toggleTheme = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'));
+
   return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <div className={clsx(className, theme)}>{children}</div>
+    </ThemeContext.Provider>
   );
 };

--- a/my-app/src/app/components/theme/ThemeSwitcher.stories.tsx
+++ b/my-app/src/app/components/theme/ThemeSwitcher.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ThemeSwitcher } from './ThemeSwitcher';
+import { ThemeProvider } from './ThemeProvider';
 
 const meta: Meta<typeof ThemeSwitcher> = {
   title: 'theme/ThemeSwitcher',
   component: ThemeSwitcher,
-  args: { children: 'ThemeSwitcher' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
 };
 export default meta;
 export const Default: StoryObj<typeof ThemeSwitcher> = {};

--- a/my-app/src/app/components/theme/ThemeSwitcher.tsx
+++ b/my-app/src/app/components/theme/ThemeSwitcher.tsx
@@ -1,14 +1,42 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import clsx from 'clsx';
+import { useTheme } from './ThemeProvider';
 
-export interface ThemeSwitcherProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+export interface ThemeSwitcherProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   className?: string;
 }
 
-/** ThemeSwitcher component */
-export const ThemeSwitcher: React.FC<ThemeSwitcherProps> = ({ className = '', children, ...rest }) => {
-  return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
-  );
-};
+const Sun = () => (
+  <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 18a6 6 0 100-12 6 6 0 000 12z" />
+    <path d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.364-7.364l-1.414 1.414M6.05 17.95l-1.414 1.414M17.95 17.95l-1.414-1.414M6.05 6.05L4.636 4.636" />
+  </svg>
+);
+
+const Moon = () => (
+  <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+  </svg>
+);
+
+export const ThemeSwitcher = React.forwardRef<HTMLButtonElement, ThemeSwitcherProps>(
+  function ThemeSwitcher({ className, ...rest }, ref) {
+    const { theme, toggleTheme } = useTheme();
+    return (
+      <motion.button
+        ref={ref}
+        aria-label="Toggle theme"
+        whileTap={{ scale: 0.9 }}
+        className={clsx(
+          'p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2',
+          className
+        )}
+        onClick={toggleTheme}
+        {...rest}
+      >
+        {theme === 'light' ? <Sun /> : <Moon />}
+      </motion.button>
+    );
+  }
+);

--- a/my-app/src/app/components/theme/__tests__/ColorPicker.test.tsx
+++ b/my-app/src/app/components/theme/__tests__/ColorPicker.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { ColorPicker } from '../ColorPicker';
-
-describe('ColorPicker', () => {
-  it('renders children', () => {
-    const { getByText } = render(<ColorPicker>Child</ColorPicker>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/theme/__tests__/ColorSwatch.test.tsx
+++ b/my-app/src/app/components/theme/__tests__/ColorSwatch.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { ColorSwatch } from '../ColorSwatch';
-
-describe('ColorSwatch', () => {
-  it('renders children', () => {
-    const { getByText } = render(<ColorSwatch>Child</ColorSwatch>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/theme/__tests__/ThemeProvider.test.tsx
+++ b/my-app/src/app/components/theme/__tests__/ThemeProvider.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { ThemeProvider } from '../ThemeProvider';
-
-describe('ThemeProvider', () => {
-  it('renders children', () => {
-    const { getByText } = render(<ThemeProvider>Child</ThemeProvider>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/theme/__tests__/ThemeSwitcher.test.tsx
+++ b/my-app/src/app/components/theme/__tests__/ThemeSwitcher.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { ThemeSwitcher } from '../ThemeSwitcher';
-
-describe('ThemeSwitcher', () => {
-  it('renders children', () => {
-    const { getByText } = render(<ThemeSwitcher>Child</ThemeSwitcher>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/theme/index.ts
+++ b/my-app/src/app/components/theme/index.ts
@@ -1,3 +1,4 @@
+export * from './theme';
 export * from './ThemeProvider';
 export * from './ThemeSwitcher';
 export * from './ColorSwatch';

--- a/my-app/src/app/components/theme/theme.ts
+++ b/my-app/src/app/components/theme/theme.ts
@@ -1,0 +1,37 @@
+export const colors = {
+  primary: '#1d4ed8',
+  secondary: '#9333ea',
+  danger: '#dc2626',
+  success: '#16a34a',
+  warning: '#ca8a04',
+  gray: '#6b7280',
+};
+
+export const spacing = {
+  0: '0px',
+  1: '4px',
+  2: '8px',
+  3: '12px',
+  4: '16px',
+  5: '20px',
+  6: '24px',
+};
+
+export const radii = {
+  sm: '0.125rem',
+  md: '0.375rem',
+  lg: '0.5rem',
+};
+
+export const shadows = {
+  sm: '0 1px 2px rgba(0,0,0,0.05)',
+  md: '0 4px 6px rgba(0,0,0,0.1)',
+  lg: '0 10px 15px rgba(0,0,0,0.15)',
+};
+
+export const fontSizes = {
+  sm: '0.875rem',
+  md: '1rem',
+  lg: '1.125rem',
+  xl: '1.25rem',
+};

--- a/my-app/src/app/components/typography/CodeBlock.stories.tsx
+++ b/my-app/src/app/components/typography/CodeBlock.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { CodeBlock } from './CodeBlock';
+import { CodeBlock, CodeBlockProps } from './CodeBlock';
 
-const meta: Meta<typeof CodeBlock> = {
+const meta: Meta<CodeBlockProps> = {
   title: 'typography/CodeBlock',
   component: CodeBlock,
-  args: { children: 'CodeBlock' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  args: { children: 'const a = 1;', language: 'ts' },
+  argTypes: {
+    language: { control: 'text' },
+  },
 };
 export default meta;
-export const Default: StoryObj<typeof CodeBlock> = {};
+export const Default: StoryObj<CodeBlockProps> = {};

--- a/my-app/src/app/components/typography/CodeBlock.tsx
+++ b/my-app/src/app/components/typography/CodeBlock.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
-export interface CodeBlockProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+export interface CodeBlockProps {
+  language?: string;
+  children: string;
   className?: string;
 }
 
-/** CodeBlock component */
-export const CodeBlock: React.FC<CodeBlockProps> = ({ className = '', children, ...rest }) => {
+export const CodeBlock: React.FC<CodeBlockProps> = ({ language, children, className }) => {
   return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
+    <pre className={clsx('overflow-auto rounded bg-gray-800 p-4', className)}>
+      <code className={clsx(language && `language-${language}`, 'text-white')}>{children}</code>
+    </pre>
   );
 };

--- a/my-app/src/app/components/typography/Heading.stories.tsx
+++ b/my-app/src/app/components/typography/Heading.stories.tsx
@@ -1,10 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Heading } from './Heading';
+import { Heading, HeadingProps } from './Heading';
 
-const meta: Meta<typeof Heading> = {
+const meta: Meta<HeadingProps> = {
   title: 'typography/Heading',
   component: Heading,
-  args: { children: 'Heading' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  args: { children: 'Heading', level: 1 },
+  argTypes: {
+    level: { control: 'number', min: 1, max: 6 },
+    size: { control: 'radio', options: ['sm', 'md', 'lg'] },
+    weight: { control: 'radio', options: ['normal', 'semibold', 'bold'] },
+  },
 };
 export default meta;
-export const Default: StoryObj<typeof Heading> = {};
+export const Default: StoryObj<HeadingProps> = {};

--- a/my-app/src/app/components/typography/Heading.tsx
+++ b/my-app/src/app/components/typography/Heading.tsx
@@ -1,14 +1,37 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
-export interface HeadingProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
   className?: string;
 }
 
-/** Heading component */
-export const Heading: React.FC<HeadingProps> = ({ className = '', children, ...rest }) => {
-  return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
-  );
+const sizeMap: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'text-sm',
+  md: 'text-xl',
+  lg: 'text-2xl',
 };
+
+const weightMap: Record<'normal' | 'semibold' | 'bold', string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(function Heading(
+  { level, size = 'lg', weight = 'bold', className, children, ...rest },
+  ref
+) {
+  const Component = `h${level}` as keyof JSX.IntrinsicElements;
+  return (
+    <Component
+      ref={ref as any}
+      className={clsx(sizeMap[size], weightMap[weight], className)}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+});

--- a/my-app/src/app/components/typography/InlineCode.stories.tsx
+++ b/my-app/src/app/components/typography/InlineCode.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { InlineCode } from './InlineCode';
+import { InlineCode, InlineCodeProps } from './InlineCode';
 
-const meta: Meta<typeof InlineCode> = {
+const meta: Meta<InlineCodeProps> = {
   title: 'typography/InlineCode',
   component: InlineCode,
-  args: { children: 'InlineCode' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  args: { children: 'code' },
 };
 export default meta;
-export const Default: StoryObj<typeof InlineCode> = {};
+export const Default: StoryObj<InlineCodeProps> = {};

--- a/my-app/src/app/components/typography/InlineCode.tsx
+++ b/my-app/src/app/components/typography/InlineCode.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
 export interface InlineCodeProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
   className?: string;
 }
 
-/** InlineCode component */
-export const InlineCode: React.FC<InlineCodeProps> = ({ className = '', children, ...rest }) => {
-  return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
-  );
-};
+export const InlineCode = React.forwardRef<HTMLElement, InlineCodeProps>(
+  function InlineCode({ className, children, ...rest }, ref) {
+    return (
+      <code
+        ref={ref}
+        className={clsx('rounded bg-gray-100 px-1 py-0.5 font-mono', className)}
+        {...rest}
+      >
+        {children}
+      </code>
+    );
+  }
+);

--- a/my-app/src/app/components/typography/Link.stories.tsx
+++ b/my-app/src/app/components/typography/Link.stories.tsx
@@ -1,10 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Link } from './Link';
+import { Link, LinkProps } from './Link';
 
-const meta: Meta<typeof Link> = {
+const meta: Meta<LinkProps> = {
   title: 'typography/Link',
   component: Link,
-  args: { children: 'Link' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  args: { href: '#', children: 'Link' },
+  argTypes: {
+    variant: { control: 'radio', options: ['primary', 'secondary'] },
+    external: { control: 'boolean' },
+  },
 };
 export default meta;
-export const Default: StoryObj<typeof Link> = {};
+export const Default: StoryObj<LinkProps> = {};

--- a/my-app/src/app/components/typography/Link.tsx
+++ b/my-app/src/app/components/typography/Link.tsx
@@ -1,14 +1,31 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
-export interface LinkProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  external?: boolean;
+  variant?: 'primary' | 'secondary';
   className?: string;
 }
 
-/** Link component */
-export const Link: React.FC<LinkProps> = ({ className = '', children, ...rest }) => {
-  return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
-  );
+const variantMap: Record<'primary' | 'secondary', string> = {
+  primary: 'text-blue-600 hover:underline',
+  secondary: 'text-gray-600 hover:underline',
 };
+
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  { href, external, variant = 'primary', className, children, ...rest },
+  ref
+) {
+  return (
+    <a
+      ref={ref}
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      className={clsx(variantMap[variant], className)}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+});

--- a/my-app/src/app/components/typography/Paragraph.stories.tsx
+++ b/my-app/src/app/components/typography/Paragraph.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Paragraph } from './Paragraph';
+import { Paragraph, ParagraphProps } from './Paragraph';
 
-const meta: Meta<typeof Paragraph> = {
+const meta: Meta<ParagraphProps> = {
   title: 'typography/Paragraph',
   component: Paragraph,
-  args: { children: 'Paragraph' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  args: { children: 'Paragraph text' },
+  argTypes: {
+    leading: { control: 'text' },
+  },
 };
 export default meta;
-export const Default: StoryObj<typeof Paragraph> = {};
+export const Default: StoryObj<ParagraphProps> = {};

--- a/my-app/src/app/components/typography/Paragraph.tsx
+++ b/my-app/src/app/components/typography/Paragraph.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
-export interface ParagraphProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+export interface ParagraphProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  leading?: string;
   className?: string;
 }
 
-/** Paragraph component */
-export const Paragraph: React.FC<ParagraphProps> = ({ className = '', children, ...rest }) => {
-  return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
-  );
-};
+export const Paragraph = React.forwardRef<HTMLParagraphElement, ParagraphProps>(
+  function Paragraph({ leading, className, children, ...rest }, ref) {
+    return (
+      <p
+        ref={ref}
+        className={clsx(leading && `leading-${leading}`, className)}
+        {...rest}
+      >
+        {children}
+      </p>
+    );
+  }
+);

--- a/my-app/src/app/components/typography/Text.stories.tsx
+++ b/my-app/src/app/components/typography/Text.stories.tsx
@@ -1,10 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Text } from './Text';
+import { Text, TextProps } from './Text';
 
-const meta: Meta<typeof Text> = {
+const meta: Meta<TextProps> = {
   title: 'typography/Text',
   component: Text,
-  args: { children: 'Text' },
+  parameters: { docs: { description: { component: "Usage of the component" } } },
+  args: { children: 'Example text', size: 'md', weight: 'normal' },
+  argTypes: {
+    as: { control: 'text' },
+    size: { control: 'radio', options: ['sm', 'md', 'lg'] },
+    weight: { control: 'radio', options: ['normal', 'semibold', 'bold'] },
+    truncate: { control: 'boolean' },
+  },
 };
 export default meta;
-export const Default: StoryObj<typeof Text> = {};
+export const Default: StoryObj<TextProps> = {};

--- a/my-app/src/app/components/typography/Text.tsx
+++ b/my-app/src/app/components/typography/Text.tsx
@@ -1,14 +1,45 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import clsx from 'clsx';
 
 export interface TextProps extends React.HTMLAttributes<HTMLElement> {
-  /** Additional class names */
+  as?: keyof JSX.IntrinsicElements;
+  size?: 'sm' | 'md' | 'lg';
+  weight?: 'normal' | 'semibold' | 'bold';
+  truncate?: boolean;
   className?: string;
 }
 
-/** Text component */
-export const Text: React.FC<TextProps> = ({ className = '', children, ...rest }) => {
-  return (
-    <motion.div className={className} {...rest}>{children}</motion.div>
-  );
+const sizeMap: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
 };
+
+const weightMap: Record<'normal' | 'semibold' | 'bold', string> = {
+  normal: 'font-normal',
+  semibold: 'font-semibold',
+  bold: 'font-bold',
+};
+
+export const Text = React.forwardRef<HTMLElement, TextProps>(function Text(
+  {
+    as: Component = 'p',
+    size = 'md',
+    weight = 'normal',
+    truncate,
+    className,
+    children,
+    ...rest
+  },
+  ref
+) {
+  return (
+    <Component
+      ref={ref as any}
+      className={clsx(sizeMap[size], weightMap[weight], { truncate }, className)}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+});

--- a/my-app/src/app/components/typography/__tests__/CodeBlock.test.tsx
+++ b/my-app/src/app/components/typography/__tests__/CodeBlock.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { CodeBlock } from '../CodeBlock';
-
-describe('CodeBlock', () => {
-  it('renders children', () => {
-    const { getByText } = render(<CodeBlock>Child</CodeBlock>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/typography/__tests__/Heading.test.tsx
+++ b/my-app/src/app/components/typography/__tests__/Heading.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { Heading } from '../Heading';
-
-describe('Heading', () => {
-  it('renders children', () => {
-    const { getByText } = render(<Heading>Child</Heading>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/typography/__tests__/InlineCode.test.tsx
+++ b/my-app/src/app/components/typography/__tests__/InlineCode.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { InlineCode } from '../InlineCode';
-
-describe('InlineCode', () => {
-  it('renders children', () => {
-    const { getByText } = render(<InlineCode>Child</InlineCode>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/typography/__tests__/Link.test.tsx
+++ b/my-app/src/app/components/typography/__tests__/Link.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { Link } from '../Link';
-
-describe('Link', () => {
-  it('renders children', () => {
-    const { getByText } = render(<Link>Child</Link>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/typography/__tests__/Paragraph.test.tsx
+++ b/my-app/src/app/components/typography/__tests__/Paragraph.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { Paragraph } from '../Paragraph';
-
-describe('Paragraph', () => {
-  it('renders children', () => {
-    const { getByText } = render(<Paragraph>Child</Paragraph>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});

--- a/my-app/src/app/components/typography/__tests__/Text.test.tsx
+++ b/my-app/src/app/components/typography/__tests__/Text.test.tsx
@@ -1,9 +1,0 @@
-import { render } from '@testing-library/react';
-import { Text } from '../Text';
-
-describe('Text', () => {
-  it('renders children', () => {
-    const { getByText } = render(<Text>Child</Text>);
-    expect(getByText('Child')).toBeInTheDocument();
-  });
-});


### PR DESCRIPTION
## Summary
- implement full theme provider system and tokens
- add color picker and swatch utilities
- build typography primitives
- add tests and stories for new components

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abc7501d48321ba8d2f142595af87